### PR TITLE
Fix compile error for g++ (Ubuntu 5.4.0-6ubuntu1~16.04.5) 5.4.0 20160609

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -64,7 +64,7 @@ constexpr int Network::INPUT_CHANNELS;
 constexpr int Network::NUM_OUTPUT_POLICY;
 constexpr int Network::NUM_VALUE_CHANNELS;
 
-std::unordered_map<Move, int> Network::move_lookup;
+std::unordered_map<Move, int, std::hash<int>> Network::move_lookup;
 
 // Input + residual block tower
 static std::vector<std::vector<float>> conv_weights;

--- a/src/Network.h
+++ b/src/Network.h
@@ -71,7 +71,7 @@ public:
       std::string getJson() const;
     };
 
-    static std::unordered_map<Move, int> move_lookup;
+    static std::unordered_map<Move, int, std::hash<int>> move_lookup;
     static Netresult get_scored_moves(const BoardHistory& state, DebugRawData* debug_data=nullptr);
 
     static void init();


### PR DESCRIPTION
The compile issue seems to be resolved when explicit passing the hash function for an int to the unordered_map. Fixes issue #2 