### PR TITLE
Fix missing import of os in parse.py

### DIFF
--- a/training/tf/parse.py
+++ b/training/tf/parse.py
@@ -25,6 +25,7 @@ import random
 import math
 import multiprocessing as mp
 import numpy as np
+import os
 import time
 import tensorflow as tf
 from tfprocess import TFProcess


### PR DESCRIPTION
This is a minor bugfix. We are joining paths using `os`:
```python
    root_dir = os.path.join(cfg['training']['path'], cfg['name'])
```
and the corresponding import is missing.