### PR TITLE
Perft

### DIFF
--- a/src/tests/perf_test.cpp
+++ b/src/tests/perf_test.cpp
@@ -26,19 +26,19 @@ TEST_F(PerfTest, InitPos) {
 TEST_F(PerfTest, Pos2) {
   bh_.set("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -");
   auto n = UCI::perft<true>(bh_, Depth(4));
-  EXPECT_EQ(n, 408'560'3);
+  EXPECT_EQ(n, 4'085'603);
 }
 
 TEST_F(PerfTest, Pos3) {
   bh_.set("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -");
   auto n = UCI::perft<true>(bh_, Depth(6));
-  EXPECT_EQ(n, 110'300'83);
+  EXPECT_EQ(n, 11'030'083);
 }
 
 TEST_F(PerfTest, Pos4) {
   bh_.set("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1");
   auto n = UCI::perft<true>(bh_, Depth(5));
-  EXPECT_EQ(n, 158'332'92);
+  EXPECT_EQ(n, 15'833'292);
 }
 
 TEST_F(PerfTest, Pos5) {


### PR DESCRIPTION
fix separator placement in perf unit tests