### PR TITLE
Fix compiling, check policy/value plane count

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,7 @@ CPPFLAGS += -MD -MP
 
 sources = Network.cpp Training.cpp UCTSearch.cpp Utils.cpp Random.cpp Parameters.cpp \
 		UCTNode.cpp OpenCL.cpp TTable.cpp Timing.cpp main.cpp Tuner.cpp \
-		Bitboard.cpp Movegen.cpp Position.cpp UCI.cpp pgn.cpp SMP.cpp
+		Bitboard.cpp Movegen.cpp Position.cpp UCI.cpp pgn.cpp SMP.cpp OpenCLScheduler.cpp
 
 objects = $(sources:.cpp=.o)
 deps = $(sources:%.cpp=%.d)

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -344,6 +344,12 @@ void Network::initialize(void) {
         }
     }
 
+    if ((bn_val_w1.size() != conv_val_b.size()) ||
+        (bn_pol_w1.size() != conv_pol_b.size()) ) {
+            throw std::runtime_error("Weights are malformed. Incorrect number "
+             "of policy/value output planes.");
+    }
+
     for (auto i = size_t{0}; i < bn_val_w1.size(); i++) {
         bn_val_w1[i] -= conv_val_b[i];
         conv_val_b[i] = 0.0f;


### PR DESCRIPTION
OpenCLScheduler was missing in Makefile.

Random weights in lczero-weights repository have incorrect value and output heads. Check the count before loading to avoid crashing.