### PR TITLE
GPU innerproduct

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -398,8 +398,32 @@ void Network::initialize(void) {
         }
 
         // Output head convolutions
-        opencl_net->push_convolve1(channels, NUM_POLICY_INPUT_PLANES, conv_pol_w);
-        opencl_net->push_convolve1(channels, NUM_VALUE_INPUT_PLANES, conv_val_w);
+        std::vector<float> bn_pol_means(bn_pol_w1.begin(), bn_pol_w1.end());
+        std::vector<float> bn_pol_stddivs(bn_pol_w2.begin(), bn_pol_w2.end());
+
+        std::vector<float> bn_val_means(bn_val_w1.begin(), bn_val_w1.end());
+        std::vector<float> bn_val_stddivs(bn_val_w2.begin(), bn_val_w2.end());
+
+        std::vector<float> ip_pol_w_vec(ip_pol_w.begin(), ip_pol_w.end());
+        std::vector<float> ip_pol_b_vec(ip_pol_b.begin(), ip_pol_b.end());
+
+        std::vector<float> ip_val_w_vec(ip1_val_w.begin(), ip1_val_w.end());
+        std::vector<float> ip_val_b_vec(ip1_val_b.begin(), ip1_val_b.end());
+
+        constexpr unsigned int width = 8;
+        constexpr unsigned int height = 8;
+
+        opencl_net->push_policy(channels, NUM_POLICY_INPUT_PLANES,
+                NUM_POLICY_INPUT_PLANES*width*height, NUM_OUTPUT_POLICY,
+                conv_pol_w,
+                bn_pol_means, bn_pol_stddivs,
+                ip_pol_w_vec, ip_pol_b_vec);
+
+        opencl_net->push_value(channels, NUM_VALUE_INPUT_PLANES,
+                NUM_VALUE_INPUT_PLANES*width*height, NUM_VALUE_CHANNELS,
+                conv_val_w,
+                bn_val_means, bn_val_stddivs,
+                ip_val_w_vec, ip_val_b_vec);
     }
 #endif
 #ifdef USE_BLAS
@@ -772,6 +796,9 @@ void Network::forward_cpu(std::vector<float>& input,
     auto V = std::vector<float>(WINOGRAD_TILE * input_channels * tiles);
     auto M = std::vector<float>(WINOGRAD_TILE * output_channels * tiles);
 
+    std::vector<float> policy_data(Network::NUM_POLICY_INPUT_PLANES * width * height);
+    std::vector<float> value_data(Network::NUM_VALUE_INPUT_PLANES * width * height);
+
     winograd_convolve3(output_channels, input, conv_weights[0], V, M, conv_out);
     batchnorm<64>(output_channels, conv_out,
                   batchnorm_means[0].data(),
@@ -799,8 +826,14 @@ void Network::forward_cpu(std::vector<float>& input,
                       batchnorm_stddivs[i + 1].data(),
                       res.data());
     }
-    convolve<1>(NUM_POLICY_INPUT_PLANES, conv_out, conv_pol_w, conv_pol_b, output_pol);
-    convolve<1>(NUM_VALUE_INPUT_PLANES, conv_out, conv_val_w, conv_val_b, output_val);
+    convolve<1>(NUM_POLICY_INPUT_PLANES, conv_out, conv_pol_w, conv_pol_b, policy_data);
+    convolve<1>(NUM_VALUE_INPUT_PLANES, conv_out, conv_val_w, conv_val_b, value_data);
+    batchnorm<width*height>(NUM_POLICY_INPUT_PLANES, policy_data, bn_pol_w1.data(), bn_pol_w2.data());
+
+    batchnorm<width*height>(NUM_VALUE_INPUT_PLANES, value_data, bn_val_w1.data(), bn_val_w2.data());
+
+    innerproduct<NUM_POLICY_INPUT_PLANES*width*height, NUM_OUTPUT_POLICY>(policy_data, ip_pol_w, ip_pol_b, output_pol);
+    innerproduct<NUM_VALUE_INPUT_PLANES*width*height, NUM_VALUE_CHANNELS>(value_data, ip1_val_w, ip1_val_b, output_val);
 }
 
 template<typename T>
@@ -880,9 +913,8 @@ Network::Netresult Network::get_scored_moves_internal(const BoardHistory& pos, N
     const auto convolve_channels = conv_pol_w.size() / conv_pol_b.size();
     std::vector<net_t> input_data;
     std::vector<net_t> output_data(convolve_channels * width * height);
-    std::vector<float> policy_data(Network::NUM_POLICY_INPUT_PLANES * width * height);
     std::vector<float> value_data(Network::NUM_VALUE_INPUT_PLANES * width * height);
-    std::vector<float> policy_out(Network::NUM_OUTPUT_POLICY);
+    std::vector<float> policy_data(Network::NUM_OUTPUT_POLICY);
     std::vector<float> softmax_data(Network::NUM_OUTPUT_POLICY);
     std::vector<float> winrate_data(Network::NUM_VALUE_CHANNELS);
     std::vector<float> winrate_out(1);
@@ -919,21 +951,13 @@ Network::Netresult Network::get_scored_moves_internal(const BoardHistory& pos, N
         compare_net_outputs(value_data, cpu_value_data);
     }
 #endif
-    // We calculate both network heads on the CPU. They are irregular
-    // and have a much lower compute densitity than the residual layers,
-    // which means they don't get much - if any - speedup from being on the
-    // GPU. See issue #185.
 
     // Get the moves
-    batchnorm<width*height>(NUM_POLICY_INPUT_PLANES, policy_data, bn_pol_w1.data(), bn_pol_w2.data());
-    innerproduct<NUM_POLICY_INPUT_PLANES*width*height, NUM_OUTPUT_POLICY>(policy_data, ip_pol_w, ip_pol_b, policy_out);
-    softmax(policy_out, softmax_data, cfg_softmax_temp);
+    softmax(policy_data, softmax_data, cfg_softmax_temp);
     std::vector<float>& outputs = softmax_data;
 
     // Now get the score
-    batchnorm<width*height>(NUM_VALUE_INPUT_PLANES, value_data, bn_val_w1.data(), bn_val_w2.data());
-    innerproduct<NUM_VALUE_INPUT_PLANES*width*height, NUM_VALUE_CHANNELS>(value_data, ip1_val_w, ip1_val_b, winrate_data);
-    innerproduct<NUM_VALUE_CHANNELS, 1>(winrate_data, ip2_val_w, ip2_val_b, winrate_out);
+    innerproduct<NUM_VALUE_CHANNELS, 1>(value_data, ip2_val_w, ip2_val_b, winrate_out);
 
     // Sigmoid
     auto winrate_sig = (1.0f + std::tanh(winrate_out[0])) / 2.0f;

--- a/src/clblast_level3/xgemv.opencl
+++ b/src/clblast_level3/xgemv.opencl
@@ -1,0 +1,128 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file contains the Xgemv kernel (generic version) for matrix-vector multiplication.
+//
+// =================================================================================================
+
+// Enables loading of this file using the C++ pre-processor's #include (C++11 standard raw string
+// literal). Comment-out this line for syntax-highlighting when developing.
+R"(
+
+// =================================================================================================
+
+// Parameters set by the tuner or by the database. Here they are given a basic default value in case
+// this kernel file is used outside of the CLBlast library.
+
+// 1: For the full version of the kernel
+#ifndef WGS1
+  #define WGS1 64     // The local work-group size
+#endif
+#ifndef WPT1
+  #define WPT1 1      // The amount of work-per-thread
+#endif
+#ifndef UNROLL1
+  #define UNROLL1 32  // Unroll factor (must be a divider of WGS1)
+#endif
+
+// 2 and 3: For the fast versions, see 'xgemv_fast.opencl'
+
+// =================================================================================================
+
+// Defines how to load the input matrix in the non-vectorized case
+INLINE_FUNC real LoadMatrixA(const __global real* restrict agm, const int x, const int y,
+                             const int a_ld, const int a_offset) {
+
+  return agm[a_ld*y + x + a_offset];
+}
+
+// =================================================================================================
+
+// Full version of the kernel
+__kernel __attribute__((reqd_work_group_size(WGS1, 1, 1)))
+void Xgemv(const int m, const int n,
+                    const __global real* restrict agm, const int a_offset, const int a_ld,
+                    const __global real* restrict xgm, const int x_offset,
+                    __global real* ygm, const int y_offset,
+                    __global real* bias, const int relu) {
+  // Local memory for the vector X
+  __local real xlm[WGS1];
+
+  // Initializes the accumulation register
+  #pragma promote_to_registers
+  real acc1[WPT1];
+  #pragma unroll
+  for (int _w = 0; _w < WPT1; _w += 1) {
+    SetToZero(acc1[_w]);
+  }
+
+  // Divides the work in a main and tail section
+  const int n_tail = n % WGS1;
+  const int n_floor = n - n_tail;
+
+  // Loops over work-group sized portions of the work
+  for (int kwg=0; kwg<n_floor; kwg+=WGS1) {
+
+    // Loads the vector X into local memory
+    const int lid = get_local_id(0);
+    xlm[lid] = xgm[(kwg + lid) + x_offset];
+
+    // Synchronizes all threads in a workgroup
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // Loops over the work per thread, and checks whether in bounds
+    #pragma unroll
+    for (int _w = 0; _w < WPT1; _w += 1) {
+      const int gid = _w*get_global_size(0) + get_global_id(0);
+      if (gid < m) {
+
+        // The multiply-add function for the main part (divisable by WGS1)
+	    for (int kloop=0; kloop<WGS1; kloop+=UNROLL1) {
+		  #pragma unroll
+		  for (int _kunroll = 0; _kunroll < UNROLL1; _kunroll += 1) {
+		    const int k = kwg + kloop + _kunroll;
+		    real value = LoadMatrixA(agm, k, gid, a_ld, a_offset);
+		    MultiplyAdd(acc1[_w], xlm[kloop + _kunroll], value);
+		  }
+	    }
+      }
+    }
+
+    // Synchronizes all threads in a workgroup
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+
+  // Loops over the work per thread, and checks whether in bounds
+  #pragma unroll
+  for (int _w = 0; _w < WPT1; _w += 1) {
+    const int gid = _w*get_global_size(0) + get_global_id(0);
+    if (gid < m) {
+
+      // The multiply-add function for the remainder part (not divisable by WGS1)
+      for (int k=n_floor; k<n; ++k) {
+        real value = LoadMatrixA(agm, k, gid, a_ld, a_offset);
+        MultiplyAdd(acc1[_w], xgm[k + x_offset], value);
+      }
+
+      // Stores the final result
+	  real out = acc1[_w] + bias[gid + y_offset];
+	  if (relu) {
+	    out = out > 0.0f ? out : 0.0f;
+	  }
+      ygm[gid + y_offset] = out;
+    }
+  }
+}
+
+// =================================================================================================
+
+// End of the C++11 raw string literal
+)"
+
+// =================================================================================================


### PR DESCRIPTION
Move policy head and first value head innerproducts from CPU to GPU. More than twice as fast on my computer than before.

TODO:
* Use faster XGemv kernel from CLBlast (Might require padding)
* Tune XGemv kernel