### PR TITLE
Fix training output to use only one chunk per game.

### DIFF
--- a/go/src/client/main.go
+++ b/go/src/client/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"io/ioutil"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -68,6 +69,14 @@ func train(networkPath string) (string, string) {
 	dir, _ := os.Getwd()
 	train_dir := path.Join(dir, fmt.Sprintf("data-%v", pid))
 	if _, err := os.Stat(train_dir); err == nil {
+		files, err := ioutil.ReadDir(train_dir)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("Cleanup training files:\n");
+		for _, f := range files {
+			fmt.Printf("%s/%s\n", train_dir, f.Name());
+		}
 		err = os.RemoveAll(train_dir)
 		if err != nil {
 			log.Fatal(err)

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -159,8 +159,8 @@ void Training::dump_training(int game_score, const std::string& out_filename) {
 }
 
 void Training::dump_training(int game_score, OutputChunker& outchunk) {
+    std::stringstream out;
     for (const auto& step : m_data) {
-        std::stringstream out;
         int kFeatureBase = Network::T_HISTORY * 14;
         for (int p = 0; p < kFeatureBase; p++) {
             const auto& plane = step.planes.bit[p];
@@ -190,8 +190,8 @@ void Training::dump_training(int game_score, OutputChunker& outchunk) {
         out << std::endl;
         // And the game result for the side to move
         out << (step.to_move == BLACK ? -game_score : game_score) << std::endl;
-        outchunk.append(out.str());
     }
+    outchunk.append(out.str());
 }
 
 void Training::dump_stats(const std::string& filename) {
@@ -200,17 +200,14 @@ void Training::dump_stats(const std::string& filename) {
 }
 
 void Training::dump_stats(OutputChunker& outchunk) {
-    {
-        std::stringstream out;
-        out << "1" << std::endl; // File format version 1
-        outchunk.append(out.str());
-    }
+    std::stringstream out;
+    out << "1" << std::endl; // File format version 1
     for (const auto& step : m_data) {
         std::stringstream out;
         out << step.net_winrate
             << " " << step.root_uct_winrate
             << " " << step.child_uct_winrate
             << " " << step.bestmove_visits << std::endl;
-        outchunk.append(out.str());
     }
+    outchunk.append(out.str());
 }

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -203,7 +203,6 @@ void Training::dump_stats(OutputChunker& outchunk) {
     std::stringstream out;
     out << "1" << std::endl; // File format version 1
     for (const auto& step : m_data) {
-        std::stringstream out;
         out << step.net_winrate
             << " " << step.root_uct_winrate
             << " " << step.child_uct_winrate


### PR DESCRIPTION
Also add some logging of what files are being deleted from the training directory.

The chunker defaults to `CHUNK_SIZE = 200` and dump_training was calling append on every Ply, so games longer than 200 plies had multiple chunks. The client only uploads the first chunk. I changed it so the entire game is stored in one chunk file.

I also added a logging of what files are being deleted from the training directory. While we are still getting things going maybe we should add even more logging? We can make it less verbose later when things seem to be working well.
