### PR TITLE
Remove eval of states without expansion

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -136,20 +136,6 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount, std::vector<Network::sc
     m_has_children = true;
 }
 
-float UCTNode::eval_state(const BoardHistory& state) {
-    auto raw_netlist = Network::get_scored_moves(state);
-
-    // DCNN returns winrate as side to move
-    auto net_eval = raw_netlist.second;
-
-    // But we score from white's point of view
-    if (state.cur().side_to_move() == BLACK) {
-        net_eval = 1.0f - net_eval;
-    }
-
-    return net_eval;
-}
-
 void UCTNode::dirichlet_noise(float epsilon, float alpha) {
     auto child_cnt = m_children.size();
     auto dirichlet_vector = std::vector<float>{};

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -45,7 +45,6 @@ public:
     bool first_visit() const;
     bool has_children() const;
     bool create_children(std::atomic<int> & nodecount, const BoardHistory& state, float& eval);
-    float eval_state(const BoardHistory& state);
     Move get_move() const;
     int get_visits() const;
     float get_score() const;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -73,9 +73,6 @@ SearchResult UCTSearch::play_simulation(BoardHistory& bh, UCTNode* const node) {
             if (success) {
                 result = SearchResult::from_eval(eval);
             }
-        } else {
-            auto eval = node->eval_state(bh);
-            result = SearchResult::from_eval(eval);
         }
     }
 
@@ -208,7 +205,7 @@ void UCTSearch::dump_analysis(int elapsed, bool force_output) {
 }
 
 bool UCTSearch::is_running() const {
-    return m_run;
+    return m_run && m_nodes < MAX_TREE_SIZE;
 }
 
 bool UCTSearch::playout_limit_reached() const {


### PR DESCRIPTION
In the spirit of mirroring progress done on leela-zero, I applied the fix for issue https://github.com/gcp/leela-zero/issues/956 from pull request https://github.com/gcp/leela-zero/pull/963.

It stops evaluating states when the number of nodes `m_nodes` is larger than the maximum tree size `MAX_TREE_SIZE`.