### PR TITLE
Add NNCache.

### DIFF
--- a/msvc/VS2017/leela-chess.vcxproj
+++ b/msvc/VS2017/leela-chess.vcxproj
@@ -26,6 +26,7 @@
     <ClInclude Include="..\..\src\Im2Col.h" />
     <ClInclude Include="..\..\src\Movegen.h" />
     <ClInclude Include="..\..\src\Network.h" />
+    <ClInclude Include="..\..\src\NNCache.h" />
     <ClInclude Include="..\..\src\OpenCL.h" />
     <ClInclude Include="..\..\src\OpenCLScheduler.h" />
     <ClInclude Include="..\..\src\Parameters.h" />
@@ -48,6 +49,7 @@
     <ClCompile Include="..\..\src\main.cpp" />
     <ClCompile Include="..\..\src\Movegen.cpp" />
     <ClCompile Include="..\..\src\Network.cpp" />
+    <ClInclude Include="..\..\src\NNCache.cpp" />
     <ClCompile Include="..\..\src\OpenCL.cpp" />
     <ClCompile Include="..\..\src\OpenCLScheduler.cpp" />
     <ClCompile Include="..\..\src\Parameters.cpp" />

--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,8 @@ CPPFLAGS += -MD -MP
 
 sources = Network.cpp Training.cpp UCTSearch.cpp Utils.cpp Random.cpp Parameters.cpp \
 		UCTNode.cpp OpenCL.cpp Timing.cpp main.cpp Tuner.cpp \
-		Bitboard.cpp Movegen.cpp Position.cpp UCI.cpp pgn.cpp SMP.cpp OpenCLScheduler.cpp
+		Bitboard.cpp Movegen.cpp Position.cpp UCI.cpp pgn.cpp SMP.cpp OpenCLScheduler.cpp \
+		NNCache.cpp
 
 objects = $(sources:.cpp=.o)
 deps = $(sources:%.cpp=%.d)

--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -1,0 +1,93 @@
+/*
+    This file is part of Leela Zero.
+    Copyright (C) 2017 Michael O
+
+    Leela Zero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Leela Zero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "config.h"
+#include <functional>
+
+#include "NNCache.h"
+#include "Utils.h"
+
+NNCache::NNCache(int size) : m_size(size) {}
+
+NNCache& NNCache::get_NNCache(void) {
+    static NNCache cache;
+    return cache;
+}
+
+bool NNCache::lookup(Key hash, Network::Netresult & result) {
+#ifndef NDEBUG
+    if (m_lookups % 10000 == 0) {
+        dump_stats();
+    }
+#endif
+    std::lock_guard<std::mutex> lock(m_mutex);
+    ++m_lookups;
+
+    auto iter = m_cache.find(hash);
+    if (iter == m_cache.end()) {
+        return false;  // Not found.
+    }
+
+    const auto& entry = iter->second;
+
+    // Found it.
+    ++m_hits;
+    result = entry->result;
+    return true;
+}
+
+void NNCache::insert(Key hash,
+                     const Network::Netresult& result) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (m_cache.find(hash) != m_cache.end()) {
+        return;  // Already in the cache.
+    }
+
+    m_cache.emplace(hash, std::make_unique<Entry>(result));
+    m_order.push_back(hash);
+    ++m_inserts;
+
+    // If the cache is too large, remove the oldest entry.
+    if (m_order.size() > m_size) {
+        m_cache.erase(m_order.front());
+        m_order.pop_front();
+    }
+}
+
+void NNCache::resize(int size) {
+    m_size = size;
+    while (m_order.size() > m_size) {
+        m_cache.erase(m_order.front());
+        m_order.pop_front();
+    }
+}
+
+void NNCache::set_size_from_playouts(int max_playouts) {
+    // cache hits are generally from last several moves so setting cache
+    // size based on playouts increases the hit rate while balancing memory
+    // usage for low playout instances. 50'000 cache entries is ~250 MB
+    auto max_size = std::min(50'000, std::max(6'000, 3 * max_playouts));
+    NNCache::get_NNCache().resize(max_size);
+}
+
+void NNCache::dump_stats() {
+    Utils::myprintf("NNCache: %d/%d hits/lookups = %.1f%% hitrate, %d inserts, %u size\n",
+        m_hits, m_lookups, 100. * m_hits / (m_lookups + 1),
+        m_inserts, m_cache.size());
+}

--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -30,12 +30,12 @@ NNCache& NNCache::get_NNCache(void) {
 }
 
 bool NNCache::lookup(Key hash, Network::Netresult & result) {
+    std::lock_guard<std::mutex> lock(m_mutex);
 #ifndef NDEBUG
     if (m_lookups % 10000 == 0) {
         dump_stats();
     }
 #endif
-    std::lock_guard<std::mutex> lock(m_mutex);
     ++m_lookups;
 
     auto iter = m_cache.find(hash);

--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -1,0 +1,79 @@
+/*
+    This file is part of Leela Zero.
+    Copyright (C) 2017 Michael O
+
+    Leela Zero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Leela Zero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NNCACHE_H_INCLUDED
+#define NNCACHE_H_INCLUDED
+
+#include "config.h"
+
+#include <deque>
+#include <mutex>
+#include <unordered_map>
+
+#include "Network.h"
+
+class NNCache {
+public:
+    // return the global NNCache
+    static NNCache& get_NNCache(void);
+
+    // Set a reasonable size gives max number of playouts
+    void set_size_from_playouts(int max_playouts);
+
+    // Resize NNCache
+    void resize(int size);
+
+    // Try and find an existing entry.
+    bool lookup(std::uint64_t hash, Network::Netresult & result);
+
+    // Insert a new entry.
+    void insert(std::uint64_t hash,
+                const Network::Netresult& result);
+
+    // Return the hit rate ratio.
+    std::pair<int, int> hit_rate() const {
+        return {m_hits, m_lookups};
+    }
+
+    void dump_stats();
+
+private:
+    NNCache(int size = 50000);  // ~ 250MB for LZGo - TODO for LZChess
+
+    std::mutex m_mutex;
+
+    size_t m_size;
+
+    // Statistics
+    int m_hits{0};
+    int m_lookups{0};
+    int m_inserts{0};
+
+    struct Entry {
+        Entry( const Network::Netresult& r)
+            : result(r) {}
+        Network::Netresult result;  // ~ 3KB for LZGo - TODO for LZChess
+    };
+
+    // Map from hash to {features, result}
+    std::unordered_map<std::uint64_t, std::unique_ptr<const Entry>> m_cache;
+    // Order entries were added to the map.
+    std::deque<size_t> m_order;
+};
+
+#endif

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -929,10 +929,11 @@ void Network::softmax(const std::vector<float>& input,
 
 Network::Netresult Network::get_scored_moves(const BoardHistory& pos, DebugRawData* debug_data, bool skip_cache) {
     Netresult result;
+    auto full_key = pos.cur().full_key();
 
     // See if we already have this in the cache.
     if (!skip_cache) {
-        if (NNCache::get_NNCache().lookup(pos.cur().key_rule50(), result)) {
+        if (NNCache::get_NNCache().lookup(full_key, result)) {
             return result;
         }
     }
@@ -942,7 +943,7 @@ Network::Netresult Network::get_scored_moves(const BoardHistory& pos, DebugRawDa
     result = get_scored_moves_internal(pos, planes, debug_data);
 
     // Insert result into cache.
-    NNCache::get_NNCache().insert(pos.cur().key_rule50(), result);
+    NNCache::get_NNCache().insert(full_key, result);
 
     return result;
 }

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -932,7 +932,7 @@ Network::Netresult Network::get_scored_moves(const BoardHistory& pos, DebugRawDa
 
     // See if we already have this in the cache.
     if (!skip_cache) {
-        if (NNCache::get_NNCache().lookup(pos.cur().key(), result)) {
+        if (NNCache::get_NNCache().lookup(pos.cur().key_rule50(), result)) {
             return result;
         }
     }
@@ -942,7 +942,7 @@ Network::Netresult Network::get_scored_moves(const BoardHistory& pos, DebugRawDa
     result = get_scored_moves_internal(pos, planes, debug_data);
 
     // Insert result into cache.
-    NNCache::get_NNCache().insert(pos.cur().key(), result);
+    NNCache::get_NNCache().insert(pos.cur().key_rule50(), result);
 
     return result;
 }

--- a/src/Network.h
+++ b/src/Network.h
@@ -75,7 +75,8 @@ public:
     };
 
     static Netresult get_scored_moves(const BoardHistory& state,
-                                      DebugRawData* debug_data=nullptr);
+                                      DebugRawData* debug_data=nullptr,
+                                      bool skip_cache = false);
 
     // Winograd filter transformation changes 3x3 filters to 4x4
     static constexpr auto WINOGRAD_ALPHA = 4;

--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -34,13 +34,15 @@
 using std::string;
 
 const char* Position::StartFEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+static constexpr auto RULE50_SCALE = 10;
 
 namespace Zobrist {
 
   Key psq[PIECE_NB][SQUARE_NB];
   Key enpassant[FILE_NB];
   Key castling[CASTLING_RIGHT_NB];
-  Key side, noPawns;
+  Key side;
+  Key rule50[100/RULE50_SCALE];
 }
 
 namespace {
@@ -116,7 +118,14 @@ void Position::init() {
   }
 
   Zobrist::side = rng.RandInt<Key>();
-  Zobrist::noPawns = rng.RandInt<Key>();
+  for (int i = 0; i < 100/RULE50_SCALE; ++i) {
+      Zobrist::rule50[i] = rng.RandInt<Key>();
+  }
+}
+
+Key Position::key_rule50() const {
+  auto rule50 = st->rule50 / 10;
+  return st->key ^ Zobrist::rule50[rule50];
 }
 
 /// Position::set() initializes the position object with the given FEN string.

--- a/src/Position.h
+++ b/src/Position.h
@@ -145,7 +145,7 @@ public:
 
   // Accessing hash keys
   Key key() const;
-  Key key_rule50() const;
+  Key full_key() const;
   Key key_after(Move m) const;
   Key material_key() const;
   Key pawn_key() const;
@@ -154,7 +154,7 @@ public:
   Color side_to_move() const;
   int game_ply() const;
   bool is_draw() const;
-	int repetitions_count() const;
+  int repetitions_count() const;
   int rule50_count() const;
 
   // Position consistency check, for debugging

--- a/src/Position.h
+++ b/src/Position.h
@@ -145,6 +145,7 @@ public:
 
   // Accessing hash keys
   Key key() const;
+  Key key_rule50() const;
   Key key_after(Move m) const;
   Key material_key() const;
   Key pawn_key() const;

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -374,7 +374,7 @@ string UCI::move(Move m) {
 /// UCI::to_move() converts a string representing a move in coordinate notation
 /// (g1f3, a7a8q) to the corresponding legal Move, if any.
 
-Move UCI::to_move(const Position& pos, string& str) { 
+Move UCI::to_move(const Position& pos, string const& str) {
     for (const auto& m : MoveList<LEGAL>(pos))
         if (str == UCI::move(m))
             return m;

--- a/src/UCI.h
+++ b/src/UCI.h
@@ -69,7 +69,7 @@ void init(OptionsMap&);
 void loop(const std::string& start);
 std::string square(Square s);
 std::string move(Move m);
-Move to_move(const Position& pos, std::string& str);
+Move to_move(const Position& pos, std::string const& str);
 
 template<bool Root>
 uint64_t perft(BoardHistory& bh, Depth depth);


### PR DESCRIPTION
Resolves #26. Way easier than tree reuse and accomplishes pretty much the same thing anyways! We start with an empty tree but very quickly build a new one using results out of NNCache. Of course we also get benefit of NNCache hits on transpositions. 

Tree reuse has some weird interactions with Dirichlet noise, so I want to think about that more before doing it.

I'm using BoardHistory.cur().key for the hash. I think this includes the position of pieces, enpassant state, castling rights, and side to move. It also includes noPawns, which appears to be unused.

Transpositions will also be NNCache hits, even if the 8 moves leading to the position are different. Tests in LZGo show it's still a net gain to treat those the same.

It does not include repetitions or rule50. I think it's fine to omit repetitions and have the search deal with that. But I think the network should know rule50 so it can give drawish evals to positions near the limit. This will encourage it to make progress more quickly. Note that even without it, the search will still notice rule50 draws. It's just that it takes more time than letting the Network see it.

I propose we change the key to include rule50. Are there some other consequences to doing that?


```
./lczero -w ~/lcnetworks/latest.txt -p 800 --noponder -t1 --start "train test 1" &>> test.log
grep lookups test.log
NNCache: 0/0 hits/lookups = 0.0% hitrate, 0 inserts, 0 size
NNCache: 1213/10000 hits/lookups = 12.1% hitrate, 8787 inserts, 8787 size
NNCache: 2521/20000 hits/lookups = 12.6% hitrate, 17479 inserts, 17479 size
NNCache: 5475/30000 hits/lookups = 18.2% hitrate, 24525 inserts, 24525 size
NNCache: 6922/40000 hits/lookups = 17.3% hitrate, 33078 inserts, 33078 size
NNCache: 8867/50000 hits/lookups = 17.7% hitrate, 41133 inserts, 41133 size
NNCache: 11542/60000 hits/lookups = 19.2% hitrate, 48458 inserts, 48458 size
NNCache: 16640/70000 hits/lookups = 23.8% hitrate, 53360 inserts, 50000 size
NNCache: 23190/80000 hits/lookups = 29.0% hitrate, 56810 inserts, 50000 size
NNCache: 29688/90000 hits/lookups = 33.0% hitrate, 60312 inserts, 50000 size
NNCache: 37749/100000 hits/lookups = 37.7% hitrate, 62251 inserts, 50000 size
NNCache: 44854/110000 hits/lookups = 40.8% hitrate, 65146 inserts, 50000 size
NNCache: 53015/120000 hits/lookups = 44.2% hitrate, 66985 inserts, 50000 size
NNCache: 61179/130000 hits/lookups = 47.1% hitrate, 68821 inserts, 50000 size
NNCache: 70398/140000 hits/lookups = 50.3% hitrate, 69602 inserts, 50000 size
NNCache: 79571/150000 hits/lookups = 53.0% hitrate, 70429 inserts, 50000 size
NNCache: 88499/160000 hits/lookups = 55.3% hitrate, 71501 inserts, 50000 size
NNCache: 97889/170000 hits/lookups = 57.6% hitrate, 72111 inserts, 50000 size
NNCache: 107666/180000 hits/lookups = 59.8% hitrate, 72334 inserts, 50000 size
```
