### PR TITLE
Guide users to client directory in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please visit the LCZero forum to discuss: https://groups.google.com/forum/#!foru
 
 # Contributing
 
-The server is live at http://162.217.248.187/.  Please download the client and give it a try.
+The server is live at http://162.217.248.187/.  Please download the client and give it a try. Go to `go/src/client` for [more information](https://github.com/glinscott/leela-chess/blob/master/go/src/client/README.md).
 
 Of course, we also appreciate code reviews, pull requests and Windows testers!
 


### PR DESCRIPTION
It confused me for a while since I did not know where to find the client initially. It seems like a good idea to guide users to client directory in README.