### PR TITLE
Update FindOpenCL.cmake

### DIFF
--- a/cmake/Modules/FindOpenCL.cmake
+++ b/cmake/Modules/FindOpenCL.cmake
@@ -66,22 +66,29 @@ function(_FIND_OPENCL_VERSION)
   CMAKE_POP_CHECK_STATE()
 endfunction()
 
-find_path(OpenCL_INCLUDE_DIR
-  NAMES
-    CL/cl.h OpenCL/cl.h
-  PATHS
-    ENV "PROGRAMFILES(X86)"
-    ENV AMDAPPSDKROOT
-    ENV INTELOCLSDKROOT
-    ENV NVSDKCOMPUTE_ROOT
-    ENV CUDA_PATH
-    ENV ATISTREAMSDKROOT
-    /usr/local/cuda
-    /usr
-  PATH_SUFFIXES
-    include
-    OpenCL/common/inc
-    "AMD APP/include")
+if(APPLE)
+  find_path(OpenCL_INCLUDE_DIR
+    NAMES
+      CL/cl.h OpenCL/cl.h)
+else()
+  find_path(OpenCL_INCLUDE_DIR
+    NAMES
+      CL/cl.h OpenCL/cl.h
+    PATHS
+      ENV "PROGRAMFILES(X86)"
+      ENV AMDAPPSDKROOT
+      ENV INTELOCLSDKROOT
+      ENV NVSDKCOMPUTE_ROOT
+      ENV CUDA_PATH
+      ENV ATISTREAMSDKROOT
+      /usr/local/cuda
+      /usr
+    PATH_SUFFIXES
+      include
+      OpenCL/common/inc
+      "AMD APP/include"
+    NO_DEFAULT_PATH)
+endif()
 
 _FIND_OPENCL_VERSION()
 
@@ -117,6 +124,9 @@ if(WIN32)
         lib/x64
         OpenCL/common/lib/x64)
   endif()
+elseif(APPLE)
+  find_library(OpenCL_LIBRARY
+    NAMES OpenCL)
 else()
   find_library(OpenCL_LIBRARY
     NAMES OpenCL
@@ -131,7 +141,8 @@ else()
       lib/x86_64
       lib/x64
       lib
-      lib64)
+      lib64
+    NO_DEFAULT_PATH)
 endif()
 
 set(OpenCL_LIBRARIES ${OpenCL_LIBRARY})

--- a/cmake/Modules/FindOpenCL.cmake
+++ b/cmake/Modules/FindOpenCL.cmake
@@ -81,8 +81,7 @@ find_path(OpenCL_INCLUDE_DIR
   PATH_SUFFIXES
     include
     OpenCL/common/inc
-    "AMD APP/include"
-  NO_DEFAULT_PATH)
+    "AMD APP/include")
 
 _FIND_OPENCL_VERSION()
 
@@ -132,8 +131,7 @@ else()
       lib/x86_64
       lib/x64
       lib
-      lib64
-    NO_DEFAULT_PATH)
+      lib64)
 endif()
 
 set(OpenCL_LIBRARIES ${OpenCL_LIBRARY})


### PR DESCRIPTION
The two "NO_DEFAULT_PATH" statements broke the ability of this module to find OpenCL on Darwin 10.13.3. I have deleted them and now the compile is fine.