### PR TITLE
Username and password not required for the client

### DIFF
--- a/go/src/client/README.md
+++ b/go/src/client/README.md
@@ -14,7 +14,12 @@ Then you just need to `go build`, and it should produce a `client` executable.
 
 First copy the `lczero` executable into the same folder as the `client` executable.
 
-Then, run!  Username and password are required parameters.
+Then, run! Default user will be "anonymous".
+```
+./client
+```
+
+But you can create an account by specifying a username and a password.
 ```
 ./client --user=myusername --password=mypassword
 ```

--- a/go/src/client/main.go
+++ b/go/src/client/main.go
@@ -19,8 +19,8 @@ import (
 )
 
 var HOSTNAME = flag.String("hostname", "http://162.217.248.187", "Address of the server")
-var USER = flag.String("user", "", "Username")
-var PASSWORD = flag.String("password", "", "Password")
+var USER = flag.String("user", "anonymous", "Username")
+var PASSWORD = flag.String("password", "anonymous", "Password")
 var GPU = flag.Int("gpu", 0, "ID of the OpenCL device to use")
 
 func uploadGame(httpClient *http.Client, path string, pgn string, nextGame client.NextGameResponse) error {
@@ -171,12 +171,6 @@ func nextGame(httpClient *http.Client, hostname string) error {
 
 func main() {
 	flag.Parse()
-	if len(*USER) == 0 {
-		log.Fatal("You must specify a username")
-	}
-	if len(*PASSWORD) == 0 {
-		log.Fatal("You must specify a non-empty password")
-	}
 
 	httpClient := &http.Client{}
 	for {


### PR DESCRIPTION
I thought it would be easier for users that just want to help, and can make a custom account if they want. Modifying the client is easier than creating a batch file on the side. 