### PR TITLE
Training chunk V2

### DIFF
--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -207,7 +207,7 @@ void Training::dump_training_v2(int game_score, OutputChunker& outchunk) {
         assert(kFeatureBase*sizeof(step.planes.bit[0].to_ullong()) == 896);
         for (int p = 0; p < kFeatureBase; p++) {
             const auto& plane = fix_v2(step.planes.bit[p]);
-            auto val = plane.to_ullong();
+            auto val = htole64(plane.to_ullong());
             assert(plane.size() % 4 == 0);
             out.write(reinterpret_cast<char*>(&val), sizeof(val));
         }

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -210,7 +210,7 @@ void Training::dump_training_v2(int game_score, OutputChunker& outchunk) {
         for (int p = 0; p < kFeatureBase; p++) {
             const auto& plane = fix_v2(step.planes.bit[p]);
             auto val = htole64(plane.to_ullong());
-            assert(plane.size() % 4 == 0);
+            assert(plane.size() == 64);
             out.write(reinterpret_cast<char*>(&val), sizeof(val));
         }
 

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -199,7 +199,9 @@ void Training::dump_training_v2(int game_score, OutputChunker& outchunk) {
         // Then the move probabilities (7696 bytes)
         assert(step.probabilities.size()*sizeof(step.probabilities[0]) == 7696);
         for (auto p : step.probabilities) {
-            out.write(reinterpret_cast<char*>(&p), sizeof(p));
+            uint32 *vp = reinterpret_cast<uint32*>(&p);
+            uint32 v = htole32(*vp);
+            out.write(reinterpret_cast<char*>(&v), sizeof(v));
         }
 
         // 112 bitplanes (896 bytes)

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -18,7 +18,6 @@
 
 #include "config.h"
 #include <cassert>
-#include <endian.h>
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -160,13 +159,15 @@ void Training::dump_training(int game_score, const std::string& out_filename) {
 }
 
 Network::BoardPlane fix_v2(Network::BoardPlane plane) {
-    for (auto bit = size_t{0}; bit < plane.size()/2; bit++) {
-      int tmp = plane[bit];
-      plane[bit] = plane[63-bit];
-      plane[63-bit] = tmp;
+    for (int i = 0, n = plane.size(); i < n; i+=8) {
+        for (auto j = 0; j < 4; j++) {
+            bool t = plane[i+j];
+            plane[i+j] = plane[i+8-j-1];
+            plane[i+8-j-1] = t;
+        }
     }
 
-    return Network::BoardPlane(htobe64(plane.to_ullong()));
+    return plane;
 }
 
 

--- a/src/Training.h
+++ b/src/Training.h
@@ -39,22 +39,22 @@ public:
 
 class OutputChunker {
 public:
-    OutputChunker(const std::string& basename, bool compress = false, size_t chunk_size = CHUNK_SIZE);
+    OutputChunker(const std::string& basename, bool compress = false, size_t num_games = NUM_GAMES);
     ~OutputChunker();
     void append(const std::string& str);
 
-    // Group this many positions in a batch.
-    static constexpr size_t CHUNK_SIZE = 200;
+    // Group this many games in a chunk.
+    static constexpr size_t NUM_GAMES = 5;
 private:
     std::string gen_chunk_name() const;
-    void flush_chunks();
+    void flush_chunk();
 
-    size_t m_step_count{0};
+    size_t m_game_count{0};
     size_t m_chunk_count{0};
     std::string m_buffer;
     std::string m_basename;
     bool m_compress{false};
-    size_t chunk_size_;
+    size_t m_games_per_chunk;
 };
 
 class Training {
@@ -62,15 +62,12 @@ public:
     static void clear_training();
     static void dump_training(int game_score, const std::string& out_filename);
     static void dump_training(int game_score, OutputChunker& outchunker);
+    static void dump_training_v2(int game_score, OutputChunker& outchunker);
     static void dump_stats(const std::string& out_filename);
     static void record(const BoardHistory& state, Move move);
     static void record(const BoardHistory& state, UCTNode& node);
 
 private:
-    // Consider only every 1/th position in a game.
-    // This ensures that positions in a chunk are from disjoint games.
-    static constexpr size_t SKIP_SIZE = 16;
-
     static void dump_stats(OutputChunker& outchunker);
     static std::vector<TimeStep> m_data;
 };

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -206,7 +206,7 @@ void generate_training_games(istringstream& is) {
   }
   auto chunker = OutputChunker{dir.string() + "/training", true};
   for (int64_t i = 0; i < num_games; i++) {
-    Training::dump_training(play_one_game(), chunker);
+    Training::dump_training_v2(play_one_game(), chunker);
   }
 }
 

--- a/src/config.h
+++ b/src/config.h
@@ -62,6 +62,7 @@ typedef unsigned char uint8;
 typedef __int64 int64;
 typedef unsigned __int64 uint64;
 uint64 htole64(uint64 v) { return v; }
+uint32 htole32(uint32 v) { return v; }
 #else
 typedef long long int int64;
 typedef  unsigned long long int uint64;

--- a/src/config.h
+++ b/src/config.h
@@ -61,6 +61,8 @@ typedef unsigned char uint8;
 #ifdef _WIN32
 typedef __int64 int64;
 typedef unsigned __int64 uint64;
+#define htole64(x) (x)
+#define htole32(x) (x)
 #else
 typedef long long int int64;
 typedef  unsigned long long int uint64;

--- a/src/config.h
+++ b/src/config.h
@@ -61,8 +61,6 @@ typedef unsigned char uint8;
 #ifdef _WIN32
 typedef __int64 int64;
 typedef unsigned __int64 uint64;
-uint64 htole64(uint64 v) { return v; }
-uint32 htole32(uint32 v) { return v; }
 #else
 typedef long long int int64;
 typedef  unsigned long long int uint64;

--- a/src/config.h
+++ b/src/config.h
@@ -59,11 +59,13 @@ typedef unsigned char uint8;
 /* Data type definitions */
 
 #ifdef _WIN32
-typedef __int64 int64 ;
+typedef __int64 int64;
 typedef unsigned __int64 uint64;
+uin64 htole64(uint64 v) { return v; }
 #else
-typedef long long int int64 ;
+typedef long long int int64;
 typedef  unsigned long long int uint64;
+#include <endian.h>
 #endif
 
 using net_t = float;

--- a/src/config.h
+++ b/src/config.h
@@ -61,7 +61,7 @@ typedef unsigned char uint8;
 #ifdef _WIN32
 typedef __int64 int64;
 typedef unsigned __int64 uint64;
-uin64 htole64(uint64 v) { return v; }
+uint64 htole64(uint64 v) { return v; }
 #else
 typedef long long int int64;
 typedef  unsigned long long int uint64;

--- a/training/tf/chunkparser.py
+++ b/training/tf/chunkparser.py
@@ -33,6 +33,9 @@ import time
 import tensorflow as tf
 import unittest
 
+# binary version
+VERSION = struct.pack('i', 2)
+
 # 14*8 planes, 4 castling, 1 color, 1 50rule, 1 movecount, 1 unused
 DATA_ITEM_LINES = 121
 
@@ -179,10 +182,7 @@ class ChunkParser:
         winner = int(text_item[120])
         assert winner == 1 or winner == -1 or winner == 0
 
-        # Apply a version
-        version = struct.pack('i', 1)
-
-        return True, self.v2_struct.pack(version, probs, planes, us_ooo, us_oo, them_ooo, them_oo, stm, rule50_count, move_count, winner)
+        return True, self.v2_struct.pack(VERSION, probs, planes, us_ooo, us_oo, them_ooo, them_oo, stm, rule50_count, move_count, winner)
 
 
     def convert_v2_to_tuple(self, content):
@@ -224,6 +224,9 @@ class ChunkParser:
             v2 format records.
         """
         if chunkdata[0:4] == b'\1\0\0\0':
+            # invalidated by bug see issue #119
+            return
+        elif chunkdata[0:4] == VERSION:
             #print("V2 chunkdata")
             for i in range(0, len(chunkdata), self.v2_struct.size):
                 if self.sample > 1:


### PR DESCRIPTION
Please review carefully, @killerducky @glinscott 

* This was verified with the new tensorflow pipeline's ChunkParser V2.
* Reduced the number of games per chunk to 5 instead of 200
* Improve readability of variables

