### PR TITLE
Add logging for opencl error.

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -48,7 +48,6 @@
 #include "UCTNode.h"
 #endif
 
-#include "Utils.h"
 #include "Random.h"
 #include "Network.h"
 #include "NNCache.h"
@@ -901,7 +900,7 @@ bool compare_net_outputs(std::vector<float>& data,
             myprintf("Error in OpenCL calculation: expected %f got %f (%lli"
                        "(error=%f%%)\n", ref[idx], data[idx], num_expansions.load(), err * 100.0);
             if (num_expansions < min_correct_expansions) {
-                printf("Update your GPU drivers or reduce the amount of games "
+                myprintf_so("Update your GPU drivers or reduce the amount of games "
                            "played simultaneously.\n");
                 throw std::runtime_error("OpenCL self-check mismatch.");
             }

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -874,8 +874,11 @@ T relative_difference(T a, T b) {
     return std::max(fabs((fa - fb) / fa), fabs((fa - fb) / fb));
 }
 
-void compare_net_outputs(std::vector<float>& data,
-                         std::vector<float>& ref) {
+bool compare_net_outputs(std::vector<float>& data,
+                         std::vector<float>& ref,
+                         bool display_only = false,
+                         std::string info = "") {
+    auto almost_equal = true;
     // The idea is to allow an OpenCL error > 5% every SELFCHECK_MIN_EXPANSIONS
     // correct expansions. As the num_expansions increases between errors > 5%,
     // we'll allow more errors to occur (max 3) before crashing. As if it
@@ -890,8 +893,12 @@ void compare_net_outputs(std::vector<float>& data,
     constexpr float relative_error = 5e-2f;
     for (auto idx = size_t{0}; idx < data.size(); ++idx) {
         auto err = relative_difference(data[idx], ref[idx]);
-        if (err > relative_error) {
-            printf("Error in OpenCL calculation: expected %f got %f (%lli"
+        if (display_only) {
+            myprintf("compare_net_outputs %s idx %d data %f ref %f err=%f\n",
+                info.c_str(), idx, data[idx], ref[idx], err);
+        } else if (err > relative_error) {
+            almost_equal = false;
+            myprintf("Error in OpenCL calculation: expected %f got %f (%lli"
                        "(error=%f%%)\n", ref[idx], data[idx], num_expansions.load(), err * 100.0);
             if (num_expansions < min_correct_expansions) {
                 printf("Update your GPU drivers or reduce the amount of games "
@@ -903,6 +910,7 @@ void compare_net_outputs(std::vector<float>& data,
             }
         }
     }
+    return almost_equal;
 }
 #endif
 
@@ -989,8 +997,25 @@ Network::Netresult Network::get_scored_moves_internal(const BoardHistory& pos, N
         auto cpu_policy_data = std::vector<float>(policy_data.size());
         auto cpu_value_data = std::vector<float>(value_data.size());
         forward_cpu(input_data, cpu_policy_data, cpu_value_data);
-        compare_net_outputs(policy_data, cpu_policy_data);
-        compare_net_outputs(value_data, cpu_value_data);
+        auto almost_equal = compare_net_outputs(policy_data, cpu_policy_data);
+        almost_equal &= compare_net_outputs(value_data, cpu_value_data);
+        if (!almost_equal) {
+            myprintf("PGN\n%s\nEND\n", pos.pgn().c_str());
+            // Compare again but with debug info
+            compare_net_outputs(policy_data, cpu_policy_data, true, "orig policy");
+            compare_net_outputs(value_data, cpu_value_data, true, "orig value");
+            // Call opencl.forward again to see if the error is reproduceable.
+            std::vector<float> value_data_retry(Network::NUM_VALUE_INPUT_PLANES * width * height);
+            std::vector<float> policy_data_retry(Network::NUM_OUTPUT_POLICY);
+            opencl.forward(input_data, policy_data_retry, value_data_retry);
+            auto almost_equal_retry = compare_net_outputs(policy_data_retry, policy_data, true, "retry policy");
+            almost_equal_retry &= compare_net_outputs(value_data_retry, value_data, true, "retry value");
+            if (!almost_equal_retry) {
+                throw std::runtime_error("OpenCL retry self-check mismatch.");
+            } else {
+                myprintf("compare_net_outputs retry was ok\n");
+            }
+        }
     }
 #endif
 

--- a/src/Tuner.cpp
+++ b/src/Tuner.cpp
@@ -398,7 +398,7 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
         }
     }
     if (best_time == 0) {
-        printf("Failed to find a working configuration.\nCheck your OpenCL drivers.\n");
+        myprintf_so("Failed to find a working configuration.\nCheck your OpenCL drivers.\n");
         throw std::runtime_error("Tuner failed to find working configuration.");
     }
     return best_params;

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -86,9 +86,7 @@ namespace {
     while (is >> token)
         value += string(" ", value.empty() ? 0 : 1) + token;
 
-    std::stringstream out;
-    out << "No such option: " << name << endl;
-    mycout(out.str());
+    myprintf_so("No such option: %s\n", name.c_str());
   }
 
 
@@ -126,9 +124,7 @@ namespace {
 
        Depth depth = Depth(d);
        uint64_t total = UCI::perft<true>(bh, depth);
-       std::stringstream out;
-       out << "Total: " << total << endl;
-       mycout(out.str());
+       myprintf_so("Total: %lld\n", total);
   }
 
 
@@ -255,9 +251,7 @@ uint64_t UCI::perft(BoardHistory& bh, Depth depth) {
           bh.cur().undo_move(m);
       }
       if (Root) {
-          std::stringstream out;
-          out << UCI::move(m) << ": " << cnt << endl;
-          mycout(out.str());
+          myprintf("%s: %lld\n", UCI::move(m).c_str(), cnt);
       }
   }
   return nodes;
@@ -275,7 +269,6 @@ void UCI::loop(const std::string& start) {
   string token, cmd = start;
   BoardHistory bh;
   bh.set(Position::StartFEN);
-  std::stringstream out;
 
   do {
       if (start.empty() && !getline(cin, cmd)) // Block here waiting for input or EOF
@@ -301,10 +294,7 @@ void UCI::loop(const std::string& start) {
       */
 
       if (token == "uci") {
-          out.str("");
-          out << "id name lczero\n"
-              << "uciok"  << endl;
-          mycout(out.str());
+          myprintf("id name lczero\nuciok\n");
       }
       else if (token == "setoption")  setoption(is);
       else if (token == "go")         go(bh, is);
@@ -312,19 +302,15 @@ void UCI::loop(const std::string& start) {
       else if (token == "position")   position(bh, is);
       // else if (token == "ucinewgame") Search::clear();
       else if (token == "isready") {
-          out.str("");
-          out << "readyok" << endl;
-          mycout(out.str());
+          myprintf("readyok\n");
       }
       // Additional custom non-UCI commands, mainly for debugging
       else if (token == "train")   generate_training_games(is);
       else if (token == "bench")   bench();
       //else if (token == "d")     sync_cout << pos << endl;
       //else if (token == "eval")  sync_cout << Eval::trace(pos) << endl;
-      else {
-          out.str("");
-          out << "Unknown command: " << token << " " << cmd << endl;
-          mycout(out.str());
+      else if (token != "quit") {
+          myprintf("Unknown command: %s\n", cmd.c_str());
       }
 
   } while (token != "quit" && start.empty()); // Command line args are one-shot

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -30,8 +30,10 @@
 #include "Training.h"
 #include "UCI.h"
 #include "UCTSearch.h"
+#include "Utils.h"
 
 using namespace std;
+using namespace Utils;
 
 enum SyncCout { IO_LOCK, IO_UNLOCK };
 std::ostream& operator<<(std::ostream&, SyncCout);
@@ -137,7 +139,7 @@ namespace {
     auto search = std::make_unique<UCTSearch>(bh.shallow_clone());
     Move move = search->think();
     bh.do_move(move);
-    printf("bestmove %s\n", UCI::move(move).c_str());
+    myprintf_so("bestmove %s\n", UCI::move(move).c_str());
   }
 
   // called when receiving the 'perft Depth' command
@@ -184,8 +186,8 @@ int play_one_game() {
   Training::clear_training();
   int game_score = play_one_game(bh);
 
-  printf("PGN\n%s\nEND\n", bh.pgn().c_str());
-  printf("Score: %d\n", game_score);
+  myprintf_so("PGN\n%s\nEND\n", bh.pgn().c_str());
+  myprintf_so("Score: %d\n", game_score);
 
   return game_score;
 }
@@ -202,7 +204,7 @@ void generate_training_games(istringstream& is) {
   fs::path dir("data-" + suffix);
   if (!fs::exists(dir)) {
     fs::create_directories(dir);
-    printf("Created dirs %s\n", dir.string().c_str());
+    myprintf_so("Created dirs %s\n", dir.string().c_str());
   }
   auto chunker = OutputChunker{dir.string() + "/training", true};
   for (int64_t i = 0; i < num_games; i++) {
@@ -235,7 +237,7 @@ Bg3 15. f4 d6 16. cxd6+ Ke8 17. Kg1 Bd7 18. a4 Rd8 {0.50s} 19. a5 Ra8 {0.54s}
   PGNParser parser(ss);
   auto game = parser.parse();
 
-  printf("%s\n", game->bh.cur().fen().c_str());
+  myprintf_so("%s\n", game->bh.cur().fen().c_str());
 
   /*
   Network::DebugRawData debug_data;

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -251,7 +251,7 @@ uint64_t UCI::perft(BoardHistory& bh, Depth depth) {
           bh.cur().undo_move(m);
       }
       if (Root) {
-          myprintf("%s: %lld\n", UCI::move(m).c_str(), cnt);
+          myprintf_so("%s: %lld\n", UCI::move(m).c_str(), cnt);
       }
   }
   return nodes;
@@ -296,7 +296,7 @@ void UCI::loop(const std::string& start) {
       */
 
       if (token == "uci") {
-          myprintf("id name lczero\nuciok\n");
+          myprintf_so("id name lczero\nuciok\n");
       }
       else if (token == "setoption")  setoption(is);
       else if (token == "go")         go(bh, is);
@@ -304,7 +304,7 @@ void UCI::loop(const std::string& start) {
       else if (token == "position")   position(bh, is);
       // else if (token == "ucinewgame") Search::clear();
       else if (token == "isready") {
-          myprintf("readyok\n");
+          myprintf_so("readyok\n");
       }
       // Additional custom non-UCI commands, mainly for debugging
       else if (token == "train")   generate_training_games(is);
@@ -312,13 +312,12 @@ void UCI::loop(const std::string& start) {
       else if (token == "d" || token == "showboard") {
 		  std::stringstream ss;
 		  ss << bh.cur();
-		  myprintf("%s\n", ss.str().c_str());
-		  //myprintf("%s\n", bh.cur().c_str());
+		  myprintf_so("%s\n", ss.str().c_str());
 	  }
 	  else if (token == "showfen") {
 	      std::stringstream ss;
 		  ss << bh.cur().fen();
-		  myprintf("%s\n", ss.str().c_str());
+		  myprintf_so("%s\n", ss.str().c_str());
 	  }
 	  else if (token == "showgame") {
 		  std::string result;
@@ -329,30 +328,30 @@ void UCI::loop(const std::string& start) {
 				  result += UCI::move(p.get_move()) + " ";
 			  }
 		  }
-		  myprintf("position startpos%s\n", result.c_str());
+		  myprintf_so("position startpos%s\n", result.c_str());
 	  }
-	  else if (token == "showpgn") myprintf("%s\n", bh.pgn().c_str());
-	  else if (token == "undo") myprintf(bh.undo_move() ? "Undone\n" : "At first move\n");
+	  else if (token == "showpgn") myprintf_so("%s\n", bh.pgn().c_str());
+	  else if (token == "undo") myprintf_so(bh.undo_move() ? "Undone\n" : "At first move\n");
 	  else if (token == "usermove" || token == "play") {
 		  std::string ms; is >> ms;
 		  Move m = UCI::to_move(bh.cur(), ms);
 		  if (m == MOVE_NONE) m = bh.cur().san_to_move(ms);
 		  if (m != MOVE_NONE) {
 			  bh.do_move(m);
-			  myprintf("usermove %s\n", UCI::move(m).c_str());
+			  myprintf_so("usermove %s\n", UCI::move(m).c_str());
 		  }
 		  else {
-			  myprintf("Illegal move: %s\n", ms.c_str());
+			  myprintf_so("Illegal move: %s\n", ms.c_str());
 		  }
 	  }
 	  else if (UCI::to_move(bh.cur(), token) != MOVE_NONE) {
 		  Move m = UCI::to_move(bh.cur(), token);
 		  bh.do_move(m);
-		  myprintf("usermove %s\n", UCI::move(m).c_str());
+		  myprintf_so("usermove %s\n", UCI::move(m).c_str());
 	  }
 		  //else if (token == "eval")  sync_cout << Eval::trace(pos) << sync_endl;
 		  else if (token != "quit") {
-		  myprintf("Unknown command: %s\n", cmd.c_str());
+		  myprintf_so("Unknown command: %s\n", cmd.c_str());
 	  }
 
   } while (start.empty()); // Command line args are one-shot

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -199,7 +199,7 @@ void UCTSearch::dump_analysis(int elapsed, bool force_output) {
     // same for nodes to depth, assume nodes = 1.8 ^ depth.
     int   depth = log(float(m_nodes)) / log(1.8);
     auto visits = m_root.get_visits();
-    printf("info depth %d nodes %d nps %d score cp %d winrate %5.2f%% time %d pv %s\n",
+    myprintf_so("info depth %d nodes %d nps %d score cp %d winrate %5.2f%% time %d pv %s\n",
              depth, visits, 100 * visits / (elapsed + 1),
              cp, winrate, 10 * elapsed, pvstring.c_str());
 }

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -109,14 +109,6 @@ void Utils::myprintf_so(const char *fmt, ...) {
     }
 }
 
-void Utils::mycout(std::string out) {
-    std::cout << out;
-    if (cfg_logfile_handle) {
-        std::lock_guard<std::mutex> lock(IOmutex);
-        fprintf(cfg_logfile_handle, out.c_str());
-    }
-}
-
 static void gtp_fprintf(FILE* file, const std::string& prefix,
                         const char *fmt, va_list ap) {
     fprintf(file, "%s ", prefix.c_str());

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -19,6 +19,7 @@
 #include "config.h"
 #include "Utils.h"
 
+#include <iostream>
 #include <mutex>
 #include <cstdarg>
 #include <cstdio>
@@ -105,6 +106,14 @@ void Utils::myprintf_so(const char *fmt, ...) {
         va_start(ap, fmt);
         vfprintf(cfg_logfile_handle, fmt, ap);
         va_end(ap);
+    }
+}
+
+void Utils::mycout(std::string out) {
+    std::cout << out;
+    if (cfg_logfile_handle) {
+        std::lock_guard<std::mutex> lock(IOmutex);
+        fprintf(cfg_logfile_handle, out.c_str());
     }
 }
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -94,6 +94,20 @@ void Utils::myprintf(const char *fmt, ...) {
     }
 }
 
+void Utils::myprintf_so(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stdout, fmt, ap);
+    va_end(ap);
+
+    if (cfg_logfile_handle) {
+        std::lock_guard<std::mutex> lock(IOmutex);
+        va_start(ap, fmt);
+        vfprintf(cfg_logfile_handle, fmt, ap);
+        va_end(ap);
+    }
+}
+
 static void gtp_fprintf(FILE* file, const std::string& prefix,
                         const char *fmt, va_list ap) {
     fprintf(file, "%s ", prefix.c_str());

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -34,6 +34,7 @@ extern Utils::ThreadPool thread_pool;
 namespace Utils {
     void myprintf(const char *fmt, ...);
     void myprintf_so(const char *fmt, ...);
+    void mycout(std::string out);
     void gtp_printf(int id, const char *fmt, ...);
     void gtp_fail_printf(int id, const char *fmt, ...);
     void log_input(const std::string& input);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -31,6 +31,7 @@ extern Utils::ThreadPool thread_pool;
 
 namespace Utils {
     void myprintf(const char *fmt, ...);
+    void myprintf_so(const char *fmt, ...);
     void gtp_printf(int id, const char *fmt, ...);
     void gtp_fail_printf(int id, const char *fmt, ...);
     void log_input(const std::string& input);

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -34,7 +34,6 @@ extern Utils::ThreadPool thread_pool;
 namespace Utils {
     void myprintf(const char *fmt, ...);
     void myprintf_so(const char *fmt, ...);
-    void mycout(std::string out);
     void gtp_printf(int id, const char *fmt, ...);
     void gtp_fail_printf(int id, const char *fmt, ...);
     void log_input(const std::string& input);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@
 using namespace Utils;
 
 static void license_blurb() {
-    printf(
+    myprintf_so(
         "LCZero Copyright (C) 2017  Gary Linscott\n"
         "Based on:"
         "Leela Chess Copyright (C) 2017 benediamond\n"
@@ -282,7 +282,7 @@ void generate_supervised_data(const std::string& filename) {
   fs::path dir("supervise-" + fp.stem().string());
   if (!fs::exists(dir)) {
     fs::create_directories(dir);
-    printf("Created dirs %s\n", dir.string().c_str());
+    myprintf_so("Created dirs %s\n", dir.string().c_str());
   }
   auto chunker = OutputChunker{dir.string() + "/training", true, 15000};
 
@@ -295,10 +295,10 @@ void generate_supervised_data(const std::string& filename) {
     Training::clear_training();
     auto game = parser.parse();
     if (game == nullptr) {
-      printf("Invalid game in %s\n", filename.c_str());
+      myprintf_so("Invalid game in %s\n", filename.c_str());
       break;
     }
-    printf("\rProcessed %d games", ++games);
+    myprintf_so("\rProcessed %d games", ++games);
     BoardHistory bh;
     bh.set(Position::StartFEN);
     for (int i = 0; i < static_cast<int>(game->bh.positions.size()) - 1; ++i) {


### PR DESCRIPTION
No change in functionality, so it will still error out under the same rules as before. I guess it will log a few errors before it errors out though.

When any error happens, it prints the PGN, prints the full comparison of opencl vs cpu, then calls opencl.forward again and prints the comparison of that and the original opencl.forward call.

On my machine I ran a few games and didn't see any errors, tested by faking errors.
