### PR TITLE
enable simple text-based manual play

### DIFF
--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -1417,6 +1417,13 @@ void BoardHistory::do_move(Move m) {
   positions.back().do_move(m, *states.back());
 }
 
+bool BoardHistory::undo_move() {
+	if (positions.size() == 1) return false;
+	states.pop_back();
+	positions.pop_back();
+	return true;
+}
+
 std::string BoardHistory::pgn() const {
   std::string result;
   for (int i = 0; i< static_cast<int>(positions.size()) - 1; ++i) {

--- a/src/Position.h
+++ b/src/Position.h
@@ -409,6 +409,7 @@ struct BoardHistory {
   void set(const std::string& fen);
   BoardHistory shallow_clone() const;
   void do_move(Move m);
+  bool undo_move();
   std::string pgn() const;
 };
 


### PR DESCRIPTION
* Added BoardHistory::undo_move.
* Added commands 'showfen', 'showboard', 'undo' and 'play [move]' to enable simple text-based manual play.

I wanted to be able to play or analyse a game with lczero, so I added a few commands to the text interface patterned after those in leelaz-go. See attached.
[lcz.txt](https://github.com/glinscott/leela-chess/files/1826007/lcz.txt)


