### PR TITLE
Change scaling factor for centipawn eval

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -195,9 +195,9 @@ void UCTSearch::dump_analysis(int64_t elapsed, bool force_output) {
     float feval = m_root.get_eval(color);
     float winrate = 100.0f * feval;
     // UCI-like output wants a depth and a cp.
-    // convert winrate to a cp estimate ... assume winrate = 1 / (1 + exp(-cp / 650))
-    // (650 can be tuned to have an output more or less matching e.g. SF, once both have similar strength)
-    int   cp = -650 * log(1 / feval - 1);
+    // convert winrate to a cp estimate ... assume winrate = 1 / (1 + exp(-cp / 91))
+    // (91 can be tuned to have an output more or less matching e.g. SF, once both have similar strength)
+    int   cp = -91 * log(1 / feval - 1);
     // same for nodes to depth, assume nodes = 1.8 ^ depth.
     int   depth = log(float(m_nodes)) / log(1.8);
     auto visits = m_root.get_visits();


### PR DESCRIPTION
Noticed that LCZero's UCI centipawn evaluation was absurdly optimistic given its winrate, so I changed the scaling factor to something more reasonable. This doesn't affect playing strength, but makes the UCI output look significantly more palatable.

(91 specifically was chosen because it maps very nicely: a winrate of 75% maps to 100 centipawns, and a winrate of 90% maps to 200 centipawns.)