### PR TITLE
Add test for long 3 fold draws.

### DIFF
--- a/src/tests/position_test.cpp
+++ b/src/tests/position_test.cpp
@@ -12,6 +12,10 @@ protected:
   }
 };
 
+void mock_shallow_repetitions(BoardHistory&& bh, int rep_cnt) {
+  EXPECT_EQ(bh.cur().repetitions_count(), rep_cnt);
+}
+
 TEST_F(PositionTest, IsDrawStartPosition) {
   Position pos;
   StateInfo si;
@@ -164,18 +168,18 @@ TEST_F(PositionTest, KeyTest) {
   bh_.do_move(UCI::to_move(bh_.cur(), "d3e3")); bh_.do_move(UCI::to_move(bh_.cur(), "d6e6"));
   bh_.do_move(UCI::to_move(bh_.cur(), "e3f3")); bh_.do_move(UCI::to_move(bh_.cur(), "e6f6"));
   bh_.do_move(UCI::to_move(bh_.cur(), "f3g3")); bh_.do_move(UCI::to_move(bh_.cur(), "f6g6"));
-  bh_ = bh_.shallow_clone();
   bh_.do_move(UCI::to_move(bh_.cur(), "g3h3"));
   EXPECT_EQ(bh_.cur().repetitions_count(), 0);
-  bh_ = bh_.shallow_clone();
+  mock_shallow_repetitions(bh_.shallow_clone(), 0);
   bh_.do_move(UCI::to_move(bh_.cur(), "g6h6"));
   EXPECT_EQ(bh_.cur().repetitions_count(), 0);
-  bh_ = bh_.shallow_clone();
+  mock_shallow_repetitions(bh_.shallow_clone(), 0);
   bh_.do_move(UCI::to_move(bh_.cur(), "h3a3"));
   EXPECT_EQ(bh_.cur().repetitions_count(), 1);
-  bh_ = bh_.shallow_clone();
+  mock_shallow_repetitions(bh_.shallow_clone(), 1);
   bh_.do_move(UCI::to_move(bh_.cur(), "h6a6"));
   EXPECT_EQ(bh_.cur().repetitions_count(), 1);
+  mock_shallow_repetitions(bh_.shallow_clone(), 1);
 }
 
 TEST_F(PositionTest, PGNTest) {

--- a/src/tests/position_test.cpp
+++ b/src/tests/position_test.cpp
@@ -152,6 +152,30 @@ TEST_F(PositionTest, KeyTest) {
   EXPECT_EQ(bh_.cur().rule50_count(), 8);
   EXPECT_TRUE(key == bh_.cur().key());
   EXPECT_FALSE(full_key == bh_.cur().full_key());
+
+  // Longer repetition test with shallow_clone
+  bh_.set(Position::StartFEN);
+  bh_.do_move(UCI::to_move(bh_.cur(), "a2a4")); bh_.do_move(UCI::to_move(bh_.cur(), "h7h5"));
+  bh_.do_move(UCI::to_move(bh_.cur(), "a1a2")); bh_.do_move(UCI::to_move(bh_.cur(), "h8h6"));
+  bh_.do_move(UCI::to_move(bh_.cur(), "a2a3")); bh_.do_move(UCI::to_move(bh_.cur(), "h6a6"));
+  bh_.do_move(UCI::to_move(bh_.cur(), "a3b3")); bh_.do_move(UCI::to_move(bh_.cur(), "a6b6"));
+  bh_.do_move(UCI::to_move(bh_.cur(), "b3c3")); bh_.do_move(UCI::to_move(bh_.cur(), "b6c6"));
+  bh_.do_move(UCI::to_move(bh_.cur(), "c3d3")); bh_.do_move(UCI::to_move(bh_.cur(), "c6d6"));
+  bh_.do_move(UCI::to_move(bh_.cur(), "d3e3")); bh_.do_move(UCI::to_move(bh_.cur(), "d6e6"));
+  bh_.do_move(UCI::to_move(bh_.cur(), "e3f3")); bh_.do_move(UCI::to_move(bh_.cur(), "e6f6"));
+  bh_.do_move(UCI::to_move(bh_.cur(), "f3g3")); bh_.do_move(UCI::to_move(bh_.cur(), "f6g6"));
+  bh_ = bh_.shallow_clone();
+  bh_.do_move(UCI::to_move(bh_.cur(), "g3h3"));
+  EXPECT_EQ(bh_.cur().repetitions_count(), 0);
+  bh_ = bh_.shallow_clone();
+  bh_.do_move(UCI::to_move(bh_.cur(), "g6h6"));
+  EXPECT_EQ(bh_.cur().repetitions_count(), 0);
+  bh_ = bh_.shallow_clone();
+  bh_.do_move(UCI::to_move(bh_.cur(), "h3a3"));
+  EXPECT_EQ(bh_.cur().repetitions_count(), 1);
+  bh_ = bh_.shallow_clone();
+  bh_.do_move(UCI::to_move(bh_.cur(), "h6a6"));
+  EXPECT_EQ(bh_.cur().repetitions_count(), 1);
 }
 
 TEST_F(PositionTest, PGNTest) {


### PR DESCRIPTION
Test is failing right now. At first I thought the way shallow_clone works will prevent it from seeing history older than 8 moves. But now I see Position has a raw pointer to StateInfo, which is a single linked list of raw pointers back to the beginning of the game. I think maybe my test is just invalid because it destroys the original bh_ when it does the shallow clone which might free the StateInfo pointers. 

I'm opening this pull just for reference related to similar problems I'm having in #182. I'm taking a break from this for now, maybe someone can point out an easy way to fix these issues?

```
tests: /home/aolsen/projects/lc-stuff/leela-chess/src/Position.cpp:629: void Position::do_move(Move, StateInfo&, bool): Assertion `&newSt != st' failed.

Thread 1 "tests" received signal SIGABRT, Aborted.
__GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
51	../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
#1  0x00007ffff4435f5d in __GI_abort () at abort.c:90
#2  0x00007ffff442bf17 in __assert_fail_base (fmt=<optimized out>, assertion=assertion@entry=0x555555667854 "&newSt != st", 
    file=file@entry=0x5555556674b0 "/home/aolsen/projects/lc-stuff/leela-chess/src/Position.cpp", line=line@entry=629, 
    function=function@entry=0x555555668000 <Position::do_move(Move, StateInfo&, bool)::__PRETTY_FUNCTION__> "void Position::do_move(Move, StateInfo&, bool)") at assert.c:92
#3  0x00007ffff442bfc2 in __GI___assert_fail (assertion=assertion@entry=0x555555667854 "&newSt != st", file=file@entry=0x5555556674b0 "/home/aolsen/projects/lc-stuff/leela-chess/src/Position.cpp", 
    line=line@entry=629, function=function@entry=0x555555668000 <Position::do_move(Move, StateInfo&, bool)::__PRETTY_FUNCTION__> "void Position::do_move(Move, StateInfo&, bool)") at assert.c:101
#4  0x00005555555fd68f in Position::do_move (this=this@entry=0x5555569d23b0, m=m@entry=(MOVE_NULL | unknown: 2990), newSt=..., givesCheck=<optimized out>)
    at /home/aolsen/projects/lc-stuff/leela-chess/src/Position.cpp:629
#5  0x00005555556016db in Position::do_move (newSt=..., m=(MOVE_NULL | unknown: 2990), this=0x5555569d23b0) at /home/aolsen/projects/lc-stuff/leela-chess/src/Position.h:394
#6  BoardHistory::do_move (this=this@entry=0x7fffffffd810, m=(MOVE_NULL | unknown: 2990)) at /home/aolsen/projects/lc-stuff/leela-chess/src/Position.cpp:1417
#7  0x00005555555d116d in PositionTest_KeyTest_Test::TestBody (this=<optimized out>) at /home/aolsen/projects/lc-stuff/leela-chess/src/tests/position_test.cpp:171
#8  0x0000555555647d29 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ()
#9  0x0000555555641e39 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ()
#10 0x00005555556250c6 in testing::Test::Run() ()
#11 0x0000555555625a3a in testing::TestInfo::Run() ()
#12 0x00005555556260bc in testing::TestCase::Run() ()
#13 0x000055555562cfc9 in testing::internal::UnitTestImpl::RunAllTests() ()
#14 0x0000555555648eef in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ()
#15 0x0000555555642c53 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ()
#16 0x000055555562baac in testing::UnitTest::Run() ()
#17 0x000055555561d3e5 in RUN_ALL_TESTS() ()
#18 0x000055555561d374 in main ()
(gdb) Quit
(gdb) quit
A debugging session is active.
```