### PR TITLE
Various cleanup: warning fixes, function names, better debugging commands

### DIFF
--- a/msvc/VS2017/leela-chess.vcxproj
+++ b/msvc/VS2017/leela-chess.vcxproj
@@ -152,7 +152,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CONSOLE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -184,7 +184,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CONSOLE;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/CL/cl2.hpp
+++ b/src/CL/cl2.hpp
@@ -357,8 +357,8 @@
         cl::unmapSVM(inputB);
         cl::unmapSVM(output2);
 
-	    cl_int error;
-	    vectorAddKernel(
+        cl_int error;
+        vectorAddKernel(
             cl::EnqueueArgs(
                 cl::NDRange(numElements/2),
                 cl::NDRange(numElements/2)),
@@ -369,7 +369,7 @@
             3,
             aPipe,
             defaultDeviceQueue,
-		    error
+            error
             );
 
         cl::copy(outputBuffer, begin(output), end(output));
@@ -3069,7 +3069,7 @@ public:
      */
     cl_int setCallback(
         cl_int type,
-        void (CL_CALLBACK * pfn_notify)(cl_event, cl_int, void *),		
+        void (CL_CALLBACK * pfn_notify)(cl_event, cl_int, void *),
         void * user_data = NULL)
     {
         return detail::errHandler(
@@ -3258,7 +3258,7 @@ public:
      *  value - not the Memory class instance.
      */
     cl_int setDestructorCallback(
-        void (CL_CALLBACK * pfn_notify)(cl_mem, void *),		
+        void (CL_CALLBACK * pfn_notify)(cl_mem, void *),
         void * user_data = NULL)
     {
         return detail::errHandler(
@@ -3849,7 +3849,7 @@ public:
         }
 
         return result;
-    }		
+    }
 #endif // CL_HPP_TARGET_OPENCL_VERSION >= 110
 };
 

--- a/src/Im2Col.h
+++ b/src/Im2Col.h
@@ -24,23 +24,23 @@
 #include <algorithm>
 
 template <unsigned long filter_size>
-void im2col(const int channels, const std::vector<net_t>& input, std::vector<float>& output) {
-    constexpr unsigned int height = 8;
-    constexpr unsigned int width = 8;
-    constexpr unsigned int channel_size = height * width;
+void im2col(const size_t channels, const std::vector<net_t>& input, std::vector<float>& output) {
+    constexpr size_t height = 8;
+    constexpr size_t width = 8;
+    constexpr size_t channel_size = height * width;
 
-    constexpr int pad = (filter_size / 2);
-    constexpr unsigned int output_h = height + 2 * pad - filter_size  + 1;
-    constexpr unsigned int output_w = width + 2 * pad - filter_size + 1;
+    constexpr size_t pad = (filter_size / 2);
+    constexpr size_t output_h = height + 2 * pad - filter_size  + 1;
+    constexpr size_t output_w = width + 2 * pad - filter_size + 1;
 
     const net_t* data_im = input.data();
     float* data_col = output.data();
 
-    for (int channel = channels; channel--; data_im += channel_size) {
-        for (unsigned int kernel_row = 0; kernel_row < filter_size; kernel_row++) {
-            for (unsigned int kernel_col = 0; kernel_col < filter_size; kernel_col++) {
+    for (size_t channel = channels; channel--; data_im += channel_size) {
+        for (size_t kernel_row = 0; kernel_row < filter_size; kernel_row++) {
+            for (size_t kernel_col = 0; kernel_col < filter_size; kernel_col++) {
                 int input_row = -pad + kernel_row;
-                for (int output_rows = output_h; output_rows; output_rows--) {
+                for (size_t output_rows = output_h; output_rows; output_rows--) {
                     if ((unsigned)input_row < height) {
                         int input_col = -pad + kernel_col;
                         for (int output_col = output_w; output_col; output_col--) {
@@ -65,10 +65,10 @@ void im2col(const int channels, const std::vector<net_t>& input, std::vector<flo
 }
 
 template <>
-void im2col<1>(const int channels,
+void im2col<1>(const size_t channels,
                const std::vector<net_t>& input,
                std::vector<float>& output) {
-    constexpr unsigned int boardsize = 8;
+    constexpr size_t boardsize = 8;
     auto outSize = size_t{channels * boardsize * boardsize};
     assert(output.size() == outSize);
     std::copy(begin(input), begin(input) + outSize, begin(output));

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -148,9 +148,9 @@ std::vector<float> Network::winograd_transform_f(const std::vector<float>& f,
 }
 
 std::vector<float> Network::zeropad_U(const std::vector<float>& U,
-                                      const int outputs, const int channels,
-                                      const int outputs_pad,
-                                      const int channels_pad) {
+                                      const size_t outputs, const size_t channels,
+                                      const size_t outputs_pad,
+                                      const size_t channels_pad) {
     // Fill with zeroes
     auto Upad = std::vector<float>(WINOGRAD_TILE * outputs_pad * channels_pad);
 
@@ -182,7 +182,7 @@ std::pair<int, int>  Network::load_v1_network(std::ifstream& wtfile) {
     // We are version 1
     myprintf("v%d...", 1);
     // First line was the version number
-    auto linecount = size_t{1};
+    auto linecount = int{1};
     auto channels = 0;
     auto line = std::string{};
     while (std::getline(wtfile, line)) {
@@ -191,8 +191,8 @@ std::pair<int, int>  Network::load_v1_network(std::ifstream& wtfile) {
         // so this tells us the amount of channels in the residual layers.
         // We are assuming all layers have the same amount of filters.
         if (linecount == 2) {
-            auto count = std::distance(std::istream_iterator<std::string>(iss),
-                                       std::istream_iterator<std::string>());
+            auto count = (int)std::distance(std::istream_iterator<std::string>(iss),
+                                            std::istream_iterator<std::string>());
             myprintf("%d channels...", count);
             channels = count;
         }
@@ -317,13 +317,13 @@ void Network::initialize(void) {
     init_move_map();
 
     // Load network from file
-    size_t channels, residual_blocks;
+    int channels, residual_blocks;
     std::tie(channels, residual_blocks) = load_network_file(cfg_weightsfile);
     if (channels == 0) {
         exit(EXIT_FAILURE);
     }
 
-    auto weight_index = size_t{0};
+    auto weight_index = int{0};
     // Input convolution
     // Winograd transform convolution weights
     conv_weights[weight_index] =
@@ -333,7 +333,7 @@ void Network::initialize(void) {
 
     // Residual block convolutions
     for (auto i = size_t{0}; i < residual_blocks * 2; i++) {
-		conv_weights[weight_index] =
+        conv_weights[weight_index] =
             winograd_transform_f(conv_weights[weight_index],
                                  channels, channels);
         weight_index++;
@@ -482,7 +482,7 @@ void Network::init_move_map() {
     }
   }
 
-  for (size_t i = 0; i < moves.size(); ++i) {
+  for (int i = 0; i < moves.size(); ++i) {
     move_lookup[moves[i]] = i;
   }
   myprintf("Generated %lu moves\n", moves.size());
@@ -676,7 +676,7 @@ void Network::winograd_convolve3(const int outputs,
                                  std::vector<float>& output) {
 
     constexpr unsigned int filter_len = WINOGRAD_ALPHA * WINOGRAD_ALPHA;
-    const auto input_channels = U.size() / (outputs * filter_len);
+    const auto input_channels = (int)U.size() / (outputs * filter_len);
 
     winograd_transform_in(input, V, input_channels);
     winograd_sgemm(U, V, M, input_channels, outputs);
@@ -684,7 +684,7 @@ void Network::winograd_convolve3(const int outputs,
 }
 
 template<unsigned int filter_size>
-void convolve(size_t outputs,
+void convolve(unsigned int outputs,
               const std::vector<net_t>& input,
               const std::vector<float>& weights,
               const std::vector<float>& biases,
@@ -694,7 +694,7 @@ void convolve(size_t outputs,
     constexpr unsigned int height = 8;
     constexpr unsigned int board_squares = width * height;
     constexpr unsigned int filter_len = filter_size * filter_size;
-    const auto input_channels = weights.size() / (biases.size() * filter_len);
+    const auto input_channels = (unsigned int)(weights.size() / (biases.size() * filter_len));
     const auto filter_dim = filter_len * input_channels;
     assert(outputs * board_squares == output.size());
 
@@ -796,7 +796,7 @@ void Network::forward_cpu(std::vector<float>& input,
     constexpr int height = 8;
     constexpr int tiles = width * height / 4;
     // Calculate output channels
-    const auto output_channels = conv_biases[0].size();
+    const auto output_channels = (int)conv_biases[0].size();
     //input_channels is the maximum number of input channels of any convolution.
     //Residual blocks are identical, but the first convolution might be bigger
     //when the network has very few filters
@@ -820,7 +820,7 @@ void Network::forward_cpu(std::vector<float>& input,
     auto conv_in = std::vector<float>(output_channels * width * height);
     auto res = std::vector<float>(output_channels * width * height);
     for (auto i = size_t{1}; i < conv_weights.size(); i += 2) {
-        auto output_channels = conv_biases[i].size();
+        auto output_channels = (int)conv_biases[i].size();
         std::swap(conv_out, conv_in);
         std::copy(begin(conv_in), end(conv_in), begin(res));
         winograd_convolve3(output_channels, conv_in,
@@ -829,7 +829,7 @@ void Network::forward_cpu(std::vector<float>& input,
                       batchnorm_means[i].data(),
                       batchnorm_stddivs[i].data());
 
-        output_channels = conv_biases[i + 1].size();
+        output_channels = (int)conv_biases[i + 1].size();
         std::swap(conv_out, conv_in);
         winograd_convolve3(output_channels, conv_in,
                            conv_weights[i + 1], V, M, conv_out);
@@ -939,7 +939,7 @@ Network::Netresult Network::get_scored_moves(const BoardHistory& pos, DebugRawDa
     auto full_key = pos.cur().full_key();
 
     // See if we already have this in the cache.
-    if (!skip_cache) {
+    if (!debug_data && !skip_cache) {
         if (NNCache::get_NNCache().lookup(full_key, result)) {
             return result;
         }
@@ -1072,7 +1072,7 @@ void Network::gather_features(const BoardHistory& bh, NNPlanes& planes) {
     // the NN here.
     planes.move_count = 0;
 
-    int mc = bh.positions.size() - 1;
+    int mc = (int)bh.positions.size() - 1;
     for (int i = 0; i < std::min(T_HISTORY, mc + 1); ++i) {
         pos = &bh.positions[mc - i];
 

--- a/src/Network.h
+++ b/src/Network.h
@@ -101,8 +101,8 @@ private:
     static std::vector<float> winograd_transform_f(const std::vector<float>& f,
         const int outputs, const int channels);
     static std::vector<float> zeropad_U(const std::vector<float>& U,
-        const int outputs, const int channels,
-        const int outputs_pad, const int channels_pad);
+        const size_t outputs, const size_t channels,
+        const size_t outputs_pad, const size_t channels_pad);
     static void winograd_transform_in(const std::vector<float>& in,
                                       std::vector<float>& V,
                                       const int C);

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -821,7 +821,7 @@ void OpenCL_Network::convolve1(int channels, int outputs,
                                    cl::NDRange(channelGroup, outputGroup, rowGroup));
     } catch (const cl::Error &e) {
         std::cerr << "Error in convolve1: " << e.what() << ": "
-	        << e.err() << std::endl;
+            << e.err() << std::endl;
         throw;
     }
 
@@ -840,7 +840,7 @@ void OpenCL_Network::convolve1(int channels, int outputs,
                                    cl::NDRange(std::min(8, outputs), 8));
     } catch (const cl::Error &e) {
         std::cerr << "Error in merge: " << e.what() << ": "
-	        << e.err() << std::endl;
+            << e.err() << std::endl;
         throw;
     }
 }
@@ -882,7 +882,7 @@ void OpenCL_Network::innerproduct(cl::Buffer& input,
                                    cl::NDRange(local_size));
     } catch (const cl::Error &e) {
         std::cerr << "Error in innerproduct: " << e.what() << ": "
-	        << e.err() << std::endl;
+            << e.err() << std::endl;
         throw;
     }
 }
@@ -1067,7 +1067,7 @@ void OpenCL::initialize(const int channels, const std::vector<int> & gpus,
             this_score += 1000 * boost::icontains(this_vendor, "nvidia");
             this_score +=  500 * boost::icontains(this_vendor, "intel");
             this_score +=  100 * (d.getInfo<CL_DEVICE_TYPE>() == CL_DEVICE_TYPE_GPU);
-            this_score +=  opencl_version * 10;
+            this_score +=  int(opencl_version * 10);
             if (!silent) {
                 myprintf("Device score:  %d\n", this_score);
             }
@@ -1105,7 +1105,7 @@ void OpenCL::initialize(const int channels, const std::vector<int> & gpus,
     try {
         context = cl::Context(best_device);
     } catch (const cl::Error &e) {
-        myprintf("Error creating OpenCL context: %s: %d", e.what(), e.err());
+        myprintf("Error creating OpenCL context: %s: %d\n", e.what(), e.err());
         throw std::runtime_error("Error creating OpenCL context.");
     }
     m_context = context;
@@ -1120,7 +1120,7 @@ void OpenCL::initialize(const int channels, const std::vector<int> & gpus,
                                 + sourceCode_sgemm
                                 + sourceCode_sgemv);
     } catch (const cl::Error &e) {
-        myprintf("Error getting kernels: %s: %d", e.what(), e.err());
+        myprintf("Error getting kernels: %s: %d\n", e.what(), e.err());
         throw std::runtime_error("Error getting OpenCL kernels.");
     }
 

--- a/src/Position.h
+++ b/src/Position.h
@@ -51,7 +51,7 @@ struct StateInfo {
   Bitboard   blockersForKing[COLOR_NB];
   Bitboard   pinnersForKing[COLOR_NB];
   Bitboard   checkSquares[PIECE_TYPE_NB];
-  Move		   move;  //--added by me--helps with undoing moves.
+  Move       move;  //--added by me--helps with undoing moves.
 };
 
 /// A list to keep track of the position states along the setup moves (from the
@@ -75,8 +75,8 @@ public:
   Position() = default;
 
   // FEN string input/output
-  Position& set(const std::string& fenStr, StateInfo* si);
-  Position& set(const std::string& code, Color c, StateInfo* si);
+  Position& init(const std::string& fenStr, StateInfo* si);
+  Position& init(const std::string& code, Color c, StateInfo* si);
   const std::string fen() const;
   void set_st(StateInfo* si) { st = si; }
 
@@ -154,6 +154,7 @@ public:
   Color side_to_move() const;
   int game_ply() const;
   bool is_draw() const;
+  bool has_no_moves() const;
   int repetitions_count() const;
   int rule50_count() const;
 
@@ -187,7 +188,7 @@ private:
   Bitboard castlingPath[CASTLING_RIGHT_NB];
   int gamePly;
   Color sideToMove;
-	StateInfo* st;
+  StateInfo* st;
 };
 
 extern std::ostream& operator<<(std::ostream& os, const Position& pos);
@@ -406,7 +407,7 @@ struct BoardHistory {
     return positions.back();
   }
 
-  void set(const std::string& fen);
+  void init(const std::string& fen);
   BoardHistory shallow_clone() const;
   void do_move(Move m);
   bool undo_move();

--- a/src/Timing.cpp
+++ b/src/Timing.cpp
@@ -22,8 +22,8 @@
 
 
 int Time::timediff_centis(Time start, Time end) {
-    return std::chrono::duration_cast<std::chrono::milliseconds>
-        (end.m_time - start.m_time).count() / 10;
+    return int(std::chrono::duration_cast<std::chrono::milliseconds>
+        (end.m_time - start.m_time).count() / 10);
 }
 
 double Time::timediff_seconds(Time start, Time end) {

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -75,7 +75,7 @@ void OutputChunker::flush_chunk() {
         auto chunk_name = gen_chunk_name();
         auto out = gzopen(chunk_name.c_str(), "wb9");
 
-        auto in_buff_size = m_buffer.size();
+        auto in_buff_size = (unsigned int)m_buffer.size();
         auto in_buff = std::make_unique<char[]>(in_buff_size);
         memcpy(in_buff.get(), m_buffer.data(), in_buff_size);
 
@@ -159,7 +159,7 @@ void Training::dump_training(int game_score, const std::string& out_filename) {
 }
 
 Network::BoardPlane fix_v2(Network::BoardPlane plane) {
-    for (int i = 0, n = plane.size(); i < n; i+=8) {
+    for (size_t i = 0, n = plane.size(); i < n; i+=8) {
         for (auto j = 0; j < 4; j++) {
             bool t = plane[i+j];
             plane[i+j] = plane[i+8-j-1];

--- a/src/Tuner.cpp
+++ b/src/Tuner.cpp
@@ -112,11 +112,11 @@ bool Tuner::valid_config_sgemm(TuneParameters p, bool exhaustive) {
 TuneParameters Tuner::get_parameters_by_int(const std::vector<Configurations>& opts,
                                         const int n) {
     TuneParameters param;
-    std::vector<size_t> choices(opts.size());
+    std::vector<int> choices(opts.size());
 
     auto cfgs = 1;
     for (auto c = size_t{0}; c < opts.size(); c++) {
-        choices[c] = opts[c].second.size();
+        choices[c] = (int)opts[c].second.size();
         cfgs *= choices[c];
     }
     auto j = n;
@@ -273,7 +273,7 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
     auto valid_params = std::vector<int>{};
     auto cfgs = 1;
     for (auto c = size_t{0}; c < opts.size(); c++) {
-        cfgs *= opts[c].second.size();
+        cfgs *= (int)opts[c].second.size();
     }
 
     auto rng = Random{0};
@@ -393,7 +393,7 @@ std::string Tuner::tune_sgemm(const int m, const int n, const int k,
             myprintf("(%u/%u) %s %.4f ms (%.1f GFLOPS)\n",
                param_counter, valid_params.size(), param_str.c_str(),
                kernel_ms, kernel_gflops);
-            best_time = sum;
+            best_time = (unsigned int)sum;
             best_params = defines;
         }
     }

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -32,9 +32,11 @@
 #include "UCI.h"
 #include "UCTSearch.h"
 #include "Utils.h"
+#include "NNCache.h"
+#include "Random.h"
 
-using namespace std;
-using namespace Utils;
+using Utils::myprintf_so;
+using Utils::myprintf;
 
 namespace {
 
@@ -43,10 +45,10 @@ namespace {
   // or the starting position ("startpos") and then makes the moves given in the
   // following move list ("moves").
 
-  void position(BoardHistory& bh, istringstream& is) {
+  void position(BoardHistory& bh, std::istringstream& is) {
 
     Move m;
-    string token, fen;
+    std::string token, fen;
 
     is >> token;
 
@@ -61,7 +63,7 @@ namespace {
     else
         return;
 
-    bh.set(fen);
+    bh.init(fen);
 
     // Parse move list (if any)
     while (is >> token && (m = UCI::to_move(bh.cur(), token)) != MOVE_NONE)
@@ -72,19 +74,19 @@ namespace {
   // setoption() is called when engine receives the "setoption" UCI command. The
   // function updates the UCI option ("name") to the given value ("value").
 
-  void setoption(istringstream& is) {
+  void setoption(std::istringstream& is) {
 
-    string token, name, value;
+    std::string token, name, value;
 
     is >> token; // Consume "name" token
 
     // Read option name (can contain spaces)
     while (is >> token && token != "value")
-        name += string(" ", name.empty() ? 0 : 1) + token;
+        name += std::string(" ", name.empty() ? 0 : 1) + token;
 
     // Read option value (can contain spaces)
     while (is >> token)
-        value += string(" ", value.empty() ? 0 : 1) + token;
+        value += std::string(" ", value.empty() ? 0 : 1) + token;
 
     myprintf_so("No such option: %s\n", name.c_str());
   }
@@ -94,10 +96,10 @@ namespace {
   // the thinking time and other parameters from the input string, then starts
   // the search.
 
-  void go(UCTSearch& search, BoardHistory& bh, istringstream& is) {
+  void go(UCTSearch& search, BoardHistory& bh, std::istringstream& is) {
 
     Limits = LimitsType();
-    string token;
+    std::string token;
 
     while (is >> token)
         if (token == "wtime")     is >> Limits.time[WHITE];
@@ -112,13 +114,23 @@ namespace {
 
     // TODO(gary): This just does the search on the UI thread...
     Move move = search.think(bh.shallow_clone());
-    bh.do_move(move);
-    myprintf_so("bestmove %s\n", UCI::move(move).c_str());
+    if (move != MOVE_NONE) {
+        bh.do_move(move);
+        myprintf_so("bestmove %s\n", UCI::to_string(move).c_str());
+    }
+    else {
+        myprintf_so("info string no move found\n");
+    }
+    bool isCheck = bh.cur().checkers();
+    bool noMoves = bh.cur().has_no_moves();
+    if (noMoves) myprintf_so(isCheck ? "info string checkmate\n" : "info string stalemate\n");
+    else if (bh.cur().is_draw()) myprintf_so("info string draw\n");
+    else if (isCheck) myprintf_so("info string check\n");
   }
 
   // called when receiving the 'perft Depth' command
-  void uci_perft(BoardHistory& bh, istringstream& is) {
-       int d;
+  void uci_perft(BoardHistory& bh, std::istringstream& is) {
+       int d = 4;
        is >> d;
 
        Depth depth = Depth(d);
@@ -134,8 +146,7 @@ int play_one_game(BoardHistory& bh) {
     if (bh.cur().is_draw()) {
       return 0;
     }
-    MoveList<LEGAL> moves(bh.cur());
-    if (moves.size() == 0) {
+    if (bh.cur().has_no_moves()) {
       if (bh.cur().checkers()) {
         // Checkmate
         return bh.cur().side_to_move() == WHITE ? -1 : 1;
@@ -156,7 +167,7 @@ int play_one_game(BoardHistory& bh) {
 
 int play_one_game() {
   BoardHistory bh;
-  bh.set(Position::StartFEN);
+  bh.init(Position::StartFEN);
 
   Training::clear_training();
   int game_score = play_one_game(bh);
@@ -167,7 +178,7 @@ int play_one_game() {
   return game_score;
 }
 
-void generate_training_games(istringstream& is) {
+void generate_training_games(std::istringstream& is) {
   namespace fs = boost::filesystem;
   std::string suffix;
   if (!(is >> suffix)) {
@@ -250,10 +261,25 @@ uint64_t UCI::perft(BoardHistory& bh, Depth depth) {
           bh.cur().undo_move(m);
       }
       if (Root) {
-          myprintf_so("%s: %lld\n", UCI::move(m).c_str(), cnt);
+          myprintf_so("%s: %lld\n", UCI::to_string(m).c_str(), cnt);
       }
   }
   return nodes;
+}
+
+/// convert a board history into a command that recreates that position. pass a shallow_clone to minimise it.
+std::string showgame(BoardHistory &bh)
+{
+    auto it = bh.positions.begin(), it_end = bh.positions.end();
+    std::string fen = it->fen();
+    std::string result = (fen == Position::StartFEN) ? std::string("position startpos") : std::string("position fen ") + fen;
+    if (++it != it_end) {
+        result += " moves";
+        for (; it != it_end; ++it) {
+            result += std::string(" ") + UCI::to_string(it->get_move());
+        }
+    }
+    return result;
 }
 
 
@@ -264,21 +290,21 @@ uint64_t UCI::perft(BoardHistory& bh, Depth depth) {
 /// In addition to the UCI ones, also some additional debug commands are supported.
 
 void UCI::loop(const std::string& start) {
-  string token, cmd = start;
+  std::string token, cmd = start;
   BoardHistory bh;
-  bh.set(Position::StartFEN);
+  bh.init(Position::StartFEN);
   auto search = std::make_unique<UCTSearch>(bh.shallow_clone());
 
   do {
-      if (start.empty() && !getline(cin, cmd)) // Block here waiting for input or EOF
+      if (start.empty() && !getline(std::cin, cmd)) // Block here waiting for input or EOF
           cmd = "quit";
 
-      log_input(cmd);
-      istringstream is(cmd);
+      Utils::log_input(cmd);
+      std::istringstream is(cmd);
       token.clear(); // Avoid a stale if getline() returns empty or blank line
-      is >> skipws >> token;
+      is >> std::skipws >> token;
 
-	  if (token == "quit" || token == "exit") break;
+      if (token == "quit" || token == "exit") break;
 
       /*
       // The GUI sends 'ponderhit' to tell us the user has played the expected move.
@@ -309,65 +335,82 @@ void UCI::loop(const std::string& start) {
       else if (token == "train")   generate_training_games(is);
       else if (token == "bench")   bench();
       else if (token == "d" || token == "showboard") {
-		  std::stringstream ss;
-		  ss << bh.cur();
-		  myprintf_so("%s\n", ss.str().c_str());
-	  }
-	  else if (token == "showfen") {
-	      std::stringstream ss;
-		  ss << bh.cur().fen();
-		  myprintf_so("%s\n", ss.str().c_str());
-	  }
-	  else if (token == "showgame") {
-		  std::string result;
-		  for (const auto &p : bh.positions) {
-			  if (result == "") {
-			      result = " "; // first position has no move
-			  } else {
-				  result += UCI::move(p.get_move()) + " ";
-			  }
-		  }
-		  myprintf_so("position startpos%s\n", result.c_str());
-	  }
-	  else if (token == "showpgn") myprintf_so("%s\n", bh.pgn().c_str());
-	  else if (token == "undo") myprintf_so(bh.undo_move() ? "Undone\n" : "At first move\n");
-	  else if (token == "usermove" || token == "play") {
-		  std::string ms; is >> ms;
-		  Move m = UCI::to_move(bh.cur(), ms);
-		  if (m == MOVE_NONE) m = bh.cur().san_to_move(ms);
-		  if (m != MOVE_NONE) {
-			  bh.do_move(m);
-			  myprintf_so("usermove %s\n", UCI::move(m).c_str());
-		  }
-		  else {
-			  myprintf_so("Illegal move: %s\n", ms.c_str());
-		  }
-	  }
-	  else if (UCI::to_move(bh.cur(), token) != MOVE_NONE) {
-		  Move m = UCI::to_move(bh.cur(), token);
-		  bh.do_move(m);
-		  myprintf_so("usermove %s\n", UCI::move(m).c_str());
-	  }
-		  //else if (token == "eval")  sync_cout << Eval::trace(pos) << sync_endl;
-		  else if (token != "quit") {
-		  myprintf_so("Unknown command: %s\n", cmd.c_str());
-	  }
+          std::stringstream ss;
+          ss << bh.cur();
+          myprintf("%s\n", ss.str().c_str());
+      }
+      else if (token == "testgo") {
+          // compare the result with "no history"
+          NNCache::get_NNCache().resize(0);
+          BoardHistory b;
+          b.positions.push_back(bh.cur());
+          go(*search, b, is);
+          bh.do_move(b.cur().get_move());
+          NNCache::get_NNCache().resize(0);
+      }
+      else if (token == "reset") {
+          bh.init(Position::StartFEN);
+          NNCache::get_NNCache().resize(0);
+          myprintf("reset board and emptied cache\n");
+      }
+      else if (token == "showfen")  myprintf("%s\n", bh.cur().fen().c_str());
+      else if (token == "showgame")  myprintf("%s\n", showgame(bh.shallow_clone()).c_str());
+      else if (token == "showpgn")  myprintf("%s\n", bh.pgn().c_str());
+      else if (token == "undo") myprintf(bh.undo_move() ? "Undone\n" : "At first move\n");
+      else if (token == "usermove" || token == "play") {
+          std::string ms;
+          while (is >> ms)
+          {
+              Move m = UCI::to_move(bh.cur(), ms);
+              if (m == MOVE_NONE) m = bh.cur().san_to_move(ms);
+              if (m != MOVE_NONE) {
+                  bh.do_move(m);
+                  myprintf_so("usermove %s\n", UCI::to_string(m).c_str());
+              }
+              else if (ms == std::to_string(((bh.cur().game_ply() / 2) + 1)) + std::string(".")) {
+                  continue; // ok to put the move number
+              }
+              else {
+                  myprintf_so("Illegal move: %s\n", ms.c_str());
+              }
+          }
+      }
+      else if (UCI::to_move(bh.cur(), token) != MOVE_NONE) {
+          Move m = UCI::to_move(bh.cur(), token);
+          bh.do_move(m);
+          myprintf_so("usermove %s\n", UCI::to_string(m).c_str());
+      }
 
+      else if (token == "eval") {
+          auto r = Network::get_scored_moves(bh);
+          auto &moves = r.first;
+          std::sort(moves.begin(), moves.end());
+          for (auto &m : moves) myprintf("%s : %f\n", bh.cur().move_to_san(m.second).c_str(), m.first);
+          myprintf("winrate %f\n", r.second);
+      }
+      else if (token == "testgame") {
+          int result = play_one_game(bh);
+          myprintf("%s\n%d\n", bh.pgn().c_str(), result);
+      }
+      else if (token != "quit") {
+          myprintf_so("Unknown command: %s\n", cmd.c_str());
+      }
   } while (start.empty()); // Command line args are one-shot
 }
 
-/// UCI::square() converts a Square to a string in algebraic notation (g1, a7, etc.)
+/// UCI::to_string() converts a Square to a string in algebraic notation (g1, a7, etc.)
 
-std::string UCI::square(Square s) {
+std::string UCI::to_string(Square s) {
+    assert(is_ok(s));
     return std::string{ char('a' + file_of(s)), char('1' + rank_of(s)) };
 }
 
-/// UCI::move() converts a Move to a string in coordinate notation (g1f3, a7a8q).
+/// UCI::to_string() converts a Move to a string in coordinate notation (g1f3, a7a8q).
 /// The only special case is castling, where we print in the e1g1 notation in
 /// normal chess mode, and in e1h1 notation in chess960 mode. Internally all
 /// castling moves are always encoded as 'king captures rook'.
 
-string UCI::move(Move m) {
+std::string UCI::to_string(Move m) {
     
     Square from = from_sq(m);
     Square to = to_sq(m);
@@ -381,7 +424,7 @@ string UCI::move(Move m) {
     if (type_of(m) == CASTLING)
         to = make_square(to > from ? FILE_G : FILE_C, rank_of(from));
     
-    string move = UCI::square(from) + UCI::square(to);
+    std::string move = UCI::to_string(from) + UCI::to_string(to);
     
     if (type_of(m) == PROMOTION)
         move += " pnbrqk"[promotion_type(m)];
@@ -393,9 +436,9 @@ string UCI::move(Move m) {
 /// UCI::to_move() converts a string representing a move in coordinate notation
 /// (g1f3, a7a8q) to the corresponding legal Move, if any.
 
-Move UCI::to_move(const Position& pos, string const& str) {
+Move UCI::to_move(const Position& pos, std::string const& str) {
     for (const auto& m : MoveList<LEGAL>(pos))
-        if (str == UCI::move(m))
+        if (str == UCI::to_string(m))
             return m;
     
     return MOVE_NONE;

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -268,7 +268,7 @@ uint64_t UCI::perft(BoardHistory& bh, Depth depth) {
 }
 
 /// convert a board history into a command that recreates that position. pass a shallow_clone to minimise it.
-std::string showgame(BoardHistory &bh)
+std::string showgame(const BoardHistory &bh)
 {
     auto it = bh.positions.begin(), it_end = bh.positions.end();
     std::string fen = it->fen();

--- a/src/UCI.h
+++ b/src/UCI.h
@@ -67,8 +67,8 @@ private:
 
 void init(OptionsMap&);
 void loop(const std::string& start);
-std::string square(Square s);
-std::string move(Move m);
+std::string to_string(Square s);
+std::string to_string(Move m);
 Move to_move(const Position& pos, std::string const& str);
 
 template<bool Root>

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -60,6 +60,7 @@ bool UCTNode::first_visit() const {
     return m_visits == 0;
 }
 
+/// returns true only if the children were created in this thread and the eval is populated
 bool UCTNode::create_children(std::atomic<int>& nodecount, const BoardHistory& state, float& eval) {
     // check whether somebody beat us to it (atomic)
     if (has_children()) {
@@ -134,7 +135,7 @@ void UCTNode::link_nodelist(std::atomic<int>& nodecount, std::vector<Network::sc
         );
     }
 
-    nodecount += m_children.size();
+    nodecount += (int)m_children.size();
     m_has_children = true;
 }
 
@@ -281,7 +282,7 @@ UCTNode* UCTNode::uct_select_child(Color color) {
     for (const auto& child : m_children) {
         parentvisits += child->get_visits();
     }
-    float numerator = std::sqrt((double)parentvisits);
+    float numerator = (float)std::sqrt((double)parentvisits);
 
     for (const auto& child : m_children) {
         // get_eval() will automatically set first-play-urgency

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -151,14 +151,6 @@ void Utils::log_input(const std::string& input) {
     }
 }
 
-size_t Utils::lcm(size_t a, size_t b) {
-    if (a % b == 0) {
-        return a;
-    }
-    size_t ret = a + (b - a % b);
-    return ret;
-}
-
 size_t Utils::ceilMultiple(size_t a, size_t b) {
     if (a % b == 0) {
         return a;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -47,14 +47,13 @@ namespace Utils {
 
     template<typename T>
     T rotl(const T x, const int k) {
-	    return (x << k) | (x >> (std::numeric_limits<T>::digits - k));
+        return (x << k) | (x >> (std::numeric_limits<T>::digits - k));
     }
 
     inline bool is7bit(int c) {
         return c >= 0 && c <= 127;
     }
 
-    size_t lcm(size_t a, size_t b);
     size_t ceilMultiple(size_t a, size_t b);
 
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,8 @@
 #include "Movegen.h"
 #include "pgn.h"
 
-using namespace Utils;
+using Utils::myprintf_so;
+using Utils::myprintf;
 
 static void license_blurb() {
     myprintf_so(
@@ -313,7 +314,7 @@ void generate_supervised_data(const std::string& filename) {
     }
     myprintf_so("\rProcessed %d games", ++games);
     BoardHistory bh;
-    bh.set(Position::StartFEN);
+    bh.init(Position::StartFEN);
     for (int i = 0; i < static_cast<int>(game->bh.positions.size()) - 1; ++i) {
       Move move = game->bh.positions[i + 1].get_move();
       Training::record(bh, move);
@@ -340,7 +341,8 @@ int main(int argc, char* argv[]) {
 
   setbuf(stdout, nullptr);
   setbuf(stderr, nullptr);
-#ifndef WIN32
+#ifndef _WIN32
+  // on windows, for some reason, this limits the cin line input to 255 characters
   setbuf(stdin, nullptr);
 #endif
   thread_pool.initialize(cfg_num_threads);

--- a/src/pgn.cpp
+++ b/src/pgn.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<PGNGame> PGNParser::parse() {
   }
 
   std::unique_ptr<PGNGame> game(new PGNGame);
-  game->bh.set(Position::StartFEN);
+  game->bh.init(Position::StartFEN);
 
   auto game_result = parse_result(result);
   if (game_result) {

--- a/src/tests/perf_test.cpp
+++ b/src/tests/perf_test.cpp
@@ -18,37 +18,37 @@ public:
 // FEN positions from https://chessprogramming.wikispaces.com/Perft+Results
 
 TEST_F(PerfTest, InitPos) {
-  bh_.set("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+  bh_.init("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
   auto n = UCI::perft<true>(bh_, Depth(4));
   EXPECT_EQ(n, 197'281);
 }
 
 TEST_F(PerfTest, Pos2) {
-  bh_.set("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -");
+  bh_.init("r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -");
   auto n = UCI::perft<true>(bh_, Depth(4));
   EXPECT_EQ(n, 4'085'603);
 }
 
 TEST_F(PerfTest, Pos3) {
-  bh_.set("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -");
+  bh_.init("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -");
   auto n = UCI::perft<true>(bh_, Depth(6));
   EXPECT_EQ(n, 11'030'083);
 }
 
 TEST_F(PerfTest, Pos4) {
-  bh_.set("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1");
+  bh_.init("r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1");
   auto n = UCI::perft<true>(bh_, Depth(5));
   EXPECT_EQ(n, 15'833'292);
 }
 
 TEST_F(PerfTest, Pos5) {
-  bh_.set("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8");
+  bh_.init("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8");
   auto n = UCI::perft<true>(bh_, Depth(4));
   EXPECT_EQ(n, 2'103'487);
 }
 
 TEST_F(PerfTest, Pos6) {
-  bh_.set("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10");
+  bh_.init("r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 10");
   auto n = UCI::perft<true>(bh_, Depth(4));
   EXPECT_EQ(n, 3'894'594);
 }

--- a/src/tests/position_test.cpp
+++ b/src/tests/position_test.cpp
@@ -19,82 +19,82 @@ void mock_shallow_repetitions(BoardHistory&& bh, int rep_cnt) {
 TEST_F(PositionTest, IsDrawStartPosition) {
   Position pos;
   StateInfo si;
-  pos.set(Position::StartFEN, &si);
+  pos.init(Position::StartFEN, &si);
   EXPECT_FALSE(pos.is_draw());
 }
 
 TEST_F(PositionTest, IsDrawBareKings) {
   Position pos;
   StateInfo si;
-  pos.set("8/8/8/4k3/8/8/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/4k3/8/8/2K5/8 w - - 0 1", &si);
   EXPECT_TRUE(pos.is_draw());
 }
 
 TEST_F(PositionTest, IsDrawSingleMinorPiece) {
   Position pos;
   StateInfo si;
-  pos.set("8/8/8/4k3/1N6/8/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/4k3/1N6/8/2K5/8 w - - 0 1", &si);
   EXPECT_TRUE(pos.is_draw());
-  pos.set("8/8/8/4k3/7b/8/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/4k3/7b/8/2K5/8 w - - 0 1", &si);
   EXPECT_TRUE(pos.is_draw());
 }
 
 TEST_F(PositionTest, IsDrawSingleMajorPieceOrPawn) {
   Position pos;
   StateInfo si;
-  pos.set("8/8/8/4k3/8/5R2/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/4k3/8/5R2/2K5/8 w - - 0 1", &si);
   EXPECT_FALSE(pos.is_draw());
-  pos.set("8/8/8/4k3/8/5q2/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/4k3/8/5q2/2K5/8 w - - 0 1", &si);
   EXPECT_FALSE(pos.is_draw());
-  pos.set("8/8/8/4k3/8/5P2/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/4k3/8/5P2/2K5/8 w - - 0 1", &si);
   EXPECT_FALSE(pos.is_draw());
 }
 
 TEST_F(PositionTest, IsDrawTwoKnights) {
   Position pos;
   StateInfo si;
-  pos.set("8/8/8/3nk3/8/5N2/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/3nk3/8/5N2/2K5/8 w - - 0 1", &si);
   EXPECT_FALSE(pos.is_draw());
-  pos.set("8/8/8/3nk3/8/5n2/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/3nk3/8/5n2/2K5/8 w - - 0 1", &si);
   EXPECT_FALSE(pos.is_draw());
 }
 
 TEST_F(PositionTest, IsDrawBishopAndKnight) {
   Position pos;
   StateInfo si;
-  pos.set("8/8/8/3bk3/8/5N2/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/3bk3/8/5N2/2K5/8 w - - 0 1", &si);
   EXPECT_FALSE(pos.is_draw());
-  pos.set("8/8/8/3Bk3/8/5N2/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/3Bk3/8/5N2/2K5/8 w - - 0 1", &si);
   EXPECT_FALSE(pos.is_draw());
 }
 
 TEST_F(PositionTest, IsDrawMultipleBishopsSameColor) {
   Position pos;
   StateInfo si;
-  pos.set("8/8/8/3Bk3/8/5B2/2K5/8 w - - 0 1", &si);
+  pos.init("8/8/8/3Bk3/8/5B2/2K5/8 w - - 0 1", &si);
   EXPECT_TRUE(pos.is_draw());
-  pos.set("8/8/8/4kb2/8/2K2B2/8/8 w - - 0 1", &si);
+  pos.init("8/8/8/4kb2/8/2K2B2/8/8 w - - 0 1", &si);
   EXPECT_TRUE(pos.is_draw());
-  pos.set("B7/1B3b2/2B3b1/4k2b/8/8/2K5/8 w - - 0 1", &si);
+  pos.init("B7/1B3b2/2B3b1/4k2b/8/8/2K5/8 w - - 0 1", &si);
   EXPECT_TRUE(pos.is_draw());
-  pos.set("B7/1B6/2B5/4k3/8/8/2K5/8 w - - 0 1", &si);
+  pos.init("B7/1B6/2B5/4k3/8/8/2K5/8 w - - 0 1", &si);
   EXPECT_TRUE(pos.is_draw());
 }
 
 TEST_F(PositionTest, IsDrawMultipleBishopsNotSameColor) {
   Position pos;
   StateInfo si;
-  pos.set("8/8/8/4k3/8/2K1bb2/8/8 w - - 0 1", &si);
+  pos.init("8/8/8/4k3/8/2K1bb2/8/8 w - - 0 1", &si);
   EXPECT_FALSE(pos.is_draw());
-  pos.set("8/8/8/4k3/8/2K1Bb2/8/8 w - - 0 1", &si);
+  pos.init("8/8/8/4k3/8/2K1Bb2/8/8 w - - 0 1", &si);
   EXPECT_FALSE(pos.is_draw());
-  pos.set("B7/1B3b2/2B3b1/4k2b/7B/8/2K5/8 w - - 0 1", &si);
+  pos.init("B7/1B3b2/2B3b1/4k2b/7B/8/2K5/8 w - - 0 1", &si);
   EXPECT_FALSE(pos.is_draw());
 }
 
 TEST_F(PositionTest, KeyTest) {
   BoardHistory bh_;
-  bh_.set(Position::StartFEN);
+  bh_.init(Position::StartFEN);
   bh_.do_move(UCI::to_move(bh_.cur(), "d2d4"));
   bh_.do_move(UCI::to_move(bh_.cur(), "d7d5"));
   bh_.do_move(UCI::to_move(bh_.cur(), "e2e4"));
@@ -102,7 +102,7 @@ TEST_F(PositionTest, KeyTest) {
   auto full_key = bh_.cur().full_key();
 
   // Normal transposition, both keys match
-  bh_.set(Position::StartFEN);
+  bh_.init(Position::StartFEN);
   bh_.do_move(UCI::to_move(bh_.cur(), "e2e4"));
   bh_.do_move(UCI::to_move(bh_.cur(), "d7d5"));
   bh_.do_move(UCI::to_move(bh_.cur(), "d2d4"));
@@ -111,7 +111,7 @@ TEST_F(PositionTest, KeyTest) {
 
   // Shuffle knights, key matches but
   // full_key doesn't because of rule50 mismatch
-  bh_.set(Position::StartFEN);
+  bh_.init(Position::StartFEN);
   bh_.do_move(UCI::to_move(bh_.cur(), "e2e4"));
   bh_.do_move(UCI::to_move(bh_.cur(), "d7d5"));
   bh_.do_move(UCI::to_move(bh_.cur(), "d2d4"));
@@ -123,7 +123,7 @@ TEST_F(PositionTest, KeyTest) {
   EXPECT_FALSE(full_key == bh_.cur().full_key());
 
   // Different setup
-  bh_.set(Position::StartFEN);
+  bh_.init(Position::StartFEN);
   bh_.do_move(UCI::to_move(bh_.cur(), "d2d4"));
   bh_.do_move(UCI::to_move(bh_.cur(), "d7d5"));
   bh_.do_move(UCI::to_move(bh_.cur(), "c1d2"));
@@ -141,7 +141,7 @@ TEST_F(PositionTest, KeyTest) {
   full_key = bh_.cur().full_key();
 
   // rule50 matches but repetitions_count doesn't
-  bh_.set(Position::StartFEN);
+  bh_.init(Position::StartFEN);
   bh_.do_move(UCI::to_move(bh_.cur(), "d2d4"));
   bh_.do_move(UCI::to_move(bh_.cur(), "d7d5"));
   bh_.do_move(UCI::to_move(bh_.cur(), "c1d2"));
@@ -158,7 +158,7 @@ TEST_F(PositionTest, KeyTest) {
   EXPECT_FALSE(full_key == bh_.cur().full_key());
 
   // Longer repetition test with shallow_clone
-  bh_.set(Position::StartFEN);
+  bh_.init(Position::StartFEN);
   bh_.do_move(UCI::to_move(bh_.cur(), "a2a4")); bh_.do_move(UCI::to_move(bh_.cur(), "h7h5"));
   bh_.do_move(UCI::to_move(bh_.cur(), "a1a2")); bh_.do_move(UCI::to_move(bh_.cur(), "h8h6"));
   bh_.do_move(UCI::to_move(bh_.cur(), "a2a3")); bh_.do_move(UCI::to_move(bh_.cur(), "h6a6"));
@@ -184,7 +184,7 @@ TEST_F(PositionTest, KeyTest) {
 
 TEST_F(PositionTest, PGNTest) {
   BoardHistory bh_;
-  bh_.set(Position::StartFEN);
+  bh_.init(Position::StartFEN);
   bh_.do_move(UCI::to_move(bh_.cur(), "f2f4"));
   bh_.do_move(UCI::to_move(bh_.cur(), "a7a6"));
   bh_.do_move(UCI::to_move(bh_.cur(), "f4f5"));
@@ -192,7 +192,7 @@ TEST_F(PositionTest, PGNTest) {
   bh_.do_move(UCI::to_move(bh_.cur(), "f5e6"));
   EXPECT_EQ(bh_.pgn(), "1. f4 a6 2. f5 e6 3. fxe6 ");
 
-  bh_.set(Position::StartFEN);
+  bh_.init(Position::StartFEN);
   bh_.do_move(UCI::to_move(bh_.cur(), "f2f4"));
   bh_.do_move(UCI::to_move(bh_.cur(), "a7a6"));
   bh_.do_move(UCI::to_move(bh_.cur(), "f4f5"));


### PR DESCRIPTION
Types
Changed int to size_t and size_t to int to remove warnings.
Explicitly cast float to int to remove warnings.
Explicitly case size() to int to remove warnings.

Clearer function names
Changed UCI::move and UCI::square to UCI::to_string(Move) and UCI::to_string(Square).
Changed Position::set to Position::init.
Removed Utils::lcm
Removed using namespace std.

Enhancement
Added more info to board ASCII printout (move number, turn and declare check)
Added debugging commands "eval" and "testgame".
Improvements to debugging commands.
Debug command 'play' now accepts a sequence of moves.
Debug command 'showgame' now emits a string that recreates the board state, including the last 8 moves.
Checkmate/Stalemate/Draw/Check now properly declared when moving with 'go' command.
Added Position::has_no_moves.

Bugfixes
Crash when 'go' command issued at end of game
Missing underscore WIN32

Project settings
Moved the shared defines to the left.