### PR TITLE
Update UCTSearch.cpp

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -199,7 +199,7 @@ void UCTSearch::dump_analysis(int64_t elapsed, bool force_output) {
     // UCI-like output wants a depth and a cp.
     // convert winrate to a cp estimate ... assume winrate = 1 / (1 + exp(-cp / 91))
     // (91 can be tuned to have an output more or less matching e.g. SF, once both have similar strength)
-    int   cp = -91 * log(1 / feval - 1);
+    int   cp = -305.66f * log(1 / feval - 1);
     // same for nodes to depth, assume nodes = 1.8 ^ depth.
     int   depth = log(float(m_nodes)) / log(1.8);
     // To report nodes, use visits.


### PR DESCRIPTION
To correct the broken conversion from winrate to centipawns. The current conversion is far too conservative and never reaches values extreme enough to allow GUIs to adjudicate win or loss. This is a major problem when trying to set up matches with long time control against other engines. The new suggested value of 305.66 in the conversion function equates a 95% winrate with a 900 centipawn advantage. 

This value is taken from the DeepMind AlphaZero paper:  "_Settings were chosen to correspond with computer chess tournament conditions: each player was allowed 1 minute per move, resignation was enabled for all players (-900 centipawns for 10 consecutive moves for Stockfish and Elmo, 5% winrate for AlphaZero)._"