### PR TITLE
Add timemanage.

### DIFF
--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -45,10 +45,11 @@ int cfg_max_threads;
 int cfg_num_threads;
 int cfg_max_playouts;
 int cfg_max_visits;
-int cfg_lagbuffer_cs;
+int cfg_lagbuffer_ms;
 int cfg_resignpct;
 int cfg_noise;
 int cfg_randomize;
+int cfg_timemanage;
 int cfg_min_resign_moves;
 uint64_t cfg_rng_seed;
 #ifdef USE_OPENCL
@@ -73,7 +74,7 @@ void Parameters::setup_default_parameters() {
 
     cfg_max_playouts = MAXINT_DIV2;
     cfg_max_visits   = 800;
-    cfg_lagbuffer_cs = 100;
+    cfg_lagbuffer_ms = 50;
 #ifdef USE_OPENCL
     cfg_gpus = { };
     cfg_sgemm_exhaustive = false;
@@ -86,6 +87,7 @@ void Parameters::setup_default_parameters() {
     cfg_resignpct = 10;
     cfg_noise = false;
     cfg_randomize = false;
+    cfg_timemanage = true;
     cfg_logfile_handle = nullptr;
     cfg_quiet = false;
     cfg_rng_seed = 0;

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -28,10 +28,11 @@ extern int cfg_max_threads;
 extern int cfg_num_threads;
 extern int cfg_max_playouts;
 extern int cfg_max_visits;
-extern int cfg_lagbuffer_cs;
+extern int cfg_lagbuffer_ms;
 extern int cfg_resignpct;
 extern int cfg_noise;
 extern int cfg_randomize;
+extern int cfg_timemanage;
 extern int cfg_min_resign_moves;
 extern uint64_t cfg_rng_seed;
 #ifdef USE_OPENCL

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "Movegen.h"
+#include "Parameters.h"
 #include "pgn.h"
 #include "Position.h"
 #include "Misc.h"
@@ -224,8 +225,11 @@ Bg3 15. f4 d6 16. cxd6+ Ke8 17. Kg1 Bd7 18. a4 Rd8 {0.50s} 19. a5 Ra8 {0.54s}
   */
 
   auto search = std::make_unique<UCTSearch>(game->bh.shallow_clone());
+  auto save_cfg_timemanage = cfg_timemanage;
+  cfg_timemanage = false;
   search->set_quiet(false);
   search->think(game->bh.shallow_clone());
+  cfg_timemanage = save_cfg_timemanage;
 }
 
 } // namespace

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -299,6 +299,10 @@ UCTNode* UCTNode::uct_select_child(Color color, bool is_root) {
     auto fpu_eval = get_eval(color) - fpu_reduction;
 
     for (const auto& child : m_children) {
+        if (!child->active()) {
+            continue;
+        }
+
         float winrate = fpu_eval;
         if (child->get_visits() > 0) {
             winrate = child->get_eval(color);
@@ -415,4 +419,12 @@ UCTNode::node_ptr_t UCTNode::find_path(std::vector<Move>& moves) {
         }
     }
     return nullptr;
+}
+
+void UCTNode::set_active(const bool active) {
+    m_status = active ? ACTIVE : PRUNED;
+}
+
+bool UCTNode::active() const {
+    return m_status == ACTIVE;
 }

--- a/src/UCTNode.h
+++ b/src/UCTNode.h
@@ -45,6 +45,8 @@ public:
     size_t count_nodes() const;
     bool first_visit() const;
     bool has_children() const;
+    void set_active(const bool active);
+    bool active() const;
     bool create_children(std::atomic<int> & nodecount, const BoardHistory& state, float& eval);
     Move get_move() const;
     int get_visits() const;
@@ -71,6 +73,11 @@ public:
     UCTNode::node_ptr_t find_path(std::vector<Move>& moves);
 
 private:
+    enum Status : char {
+        //INVALID, // superko for Go, NA for chess.
+        PRUNED,
+        ACTIVE
+    };
     void link_nodelist(std::atomic<int>& nodecount, std::vector<Network::scored_node>& nodelist, float init_eval);
 
     // Move
@@ -82,6 +89,7 @@ private:
     float m_score;
     float m_init_eval;
     std::atomic<double> m_whiteevals{0};
+    std::atomic<Status> m_status{ACTIVE};
     // Is someone adding scores to this node?
     // We don't need to unset this.
     bool m_is_expanding{false};

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -35,7 +35,6 @@
 #include "Parameters.h"
 #include "Utils.h"
 #include "Network.h"
-#include "Parameters.h"
 #include "Training.h"
 #include "Types.h"
 #include "TimeMan.h"
@@ -218,6 +217,77 @@ bool UCTSearch::is_running() const {
     return m_run && m_nodes < MAX_TREE_SIZE;
 }
 
+int UCTSearch::est_playouts_left() const {
+    auto elapsed_millis = now() - m_start_time;
+    auto playouts = m_playouts.load();
+    if (m_target_time < 0) {
+        // No time control, use playouts or visits.
+        const auto playouts_left = std::min(m_maxplayouts - playouts,
+                                            m_maxvisits - m_root->get_visits());
+        return playouts_left;
+    } else if (elapsed_millis < 1000 || playouts < 100) {
+        // Until we reach 1 second or 100 playouts playout_rate
+        // is not reliable, so just return max.
+        return MAXINT_DIV2;
+    } else {
+        const auto playout_rate = 1.0f * playouts / elapsed_millis;
+        const auto time_left = m_target_time - elapsed_millis;
+        return static_cast<int>(std::ceil(playout_rate * time_left));
+    }
+}
+
+size_t UCTSearch::prune_noncontenders() {
+    auto Nfirst = 0;
+    for (const auto& node : m_root->get_children()) {
+        Nfirst = std::max(Nfirst, node->get_visits());
+    }
+    const auto min_required_visits =
+        Nfirst - est_playouts_left();
+    auto pruned_nodes = size_t{0};
+    for (const auto& node : m_root->get_children()) {
+        const auto has_enough_visits =
+            node->get_visits() >= min_required_visits;
+        node->set_active(has_enough_visits);
+        if (!has_enough_visits) {
+            ++pruned_nodes;
+        }
+    }
+
+    return pruned_nodes;
+}
+
+bool UCTSearch::have_alternate_moves() {
+    if (!cfg_timemanage) {
+        // When timemanage is off always return true.
+        // Even if there is only one legal move, we need to get
+        // an accurate winrate for self play training output.
+        return true;
+    }
+    auto pruned = prune_noncontenders();
+    if (pruned == m_root->get_children().size() - 1) {
+        auto elapsed_millis = now() - m_start_time;
+        if (m_target_time > 0) {
+            // TODO: Until we are stable revert to always printing.
+            // Later we can put back this term if logging is too spammy.
+            //     && m_target_time - elapsed_millis > 500
+            // So for now the comment below does not apply.
+            // TODO: In a timed search we will essentially always exit because
+            // TODO: the remaining time is too short to let another move win, so
+            // TODO: avoid spamming this message every move. We'll print it if we
+            // TODO: save at least half a second.
+            //
+            myprintf("Time Budgeted %0.2fs Used %0.2fs Saved %0.2fs (%0.f%%)\n",
+                m_target_time / 1000.0f,
+                elapsed_millis / 1000.0f,
+                (m_target_time - elapsed_millis) / 1000.0f,
+                100.0f * (m_target_time - elapsed_millis) / m_target_time);
+        }
+        return false;
+    }
+    return true;
+}
+
+
 bool UCTSearch::pv_limit_reached() const {
     return m_playouts >= m_maxplayouts
         || m_root->get_visits() >= m_maxvisits;
@@ -306,6 +376,7 @@ Move UCTSearch::think(BoardHistory&& new_bh) {
         // check if we should still search
         keeprunning = is_running();
         keeprunning &= !halt_search();
+        keeprunning &= have_alternate_moves();
 
     } while(keeprunning);
 
@@ -314,6 +385,11 @@ Move UCTSearch::think(BoardHistory&& new_bh) {
     tg.wait_all();
     if (!m_root->has_children()) {
         return MOVE_NONE;
+    }
+
+    // reactivate all pruned root children
+    for (const auto& node : m_root->get_children()) {
+        node->set_active(true);
     }
 
     // display search info
@@ -362,12 +438,16 @@ int UCTSearch::get_search_time() {
         return -1;
     }
 
-    return Limits.movetime ? Limits.movetime : Time.optimum();
+    auto search_time = Limits.movetime ? Limits.movetime : Time.optimum();
+    search_time -= cfg_lagbuffer_ms;
+    return search_time;
 }
 
 // Used to check if we've run out of time or reached out playout limit
 bool UCTSearch::halt_search() {
-    return m_target_time < 0 ? pv_limit_reached() : m_target_time - 50 < now() - m_start_time;
+    auto elapsed_millis = now() - m_start_time;
+    return m_target_time < 0 ? pv_limit_reached()
+        : m_target_time < elapsed_millis;
 }
 
 void UCTSearch::set_playout_limit(int playouts) {

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -74,11 +74,14 @@ public:
     void set_quiet(bool flag);
     void ponder();
     bool is_running() const;
+    int est_playouts_left() const;
+    size_t prune_noncontenders();
+    bool have_alternate_moves();
     bool pv_limit_reached() const;
     void increment_playouts();
     bool halt_search();
     SearchResult play_simulation(BoardHistory& bh, UCTNode* const node);
-    
+
 private:
     void dump_stats(BoardHistory& pos, UCTNode& parent);
     std::string get_pv(BoardHistory& pos, UCTNode& parent);
@@ -90,8 +93,8 @@ private:
     std::unique_ptr<UCTNode> m_root;
     std::atomic<int> m_nodes{0};
     std::atomic<int> m_playouts{0};
-    std::atomic<int64_t> m_target_time{0};
-    std::atomic<int64_t> m_start_time{0};
+    int64_t m_target_time{0};
+    int64_t m_start_time{0};
     std::atomic<bool> m_run{false};
     int m_maxplayouts;
     int m_maxvisits;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,6 +199,9 @@ static std::string parse_commandline(int argc, char *argv[]) {
 
     if (vm.count("randomize")) {
         cfg_randomize = true;
+        // When cfg_randomize is on, we need an accurate estimate of
+        // how good/bad all moves are, so turn cfg_timemanage off.
+        cfg_timemanage = false;
     }
 
     if (vm.count("playouts")) {


### PR DESCRIPTION
Fixes #183. Ported from LZGo's implementation. 
Short 50 game test vs unmodified next gave +138 Elo (+26 =17 -7).

After 1 second, calculate how many playouts per second we are getting. Use this to estimate how many more playouts we can do before time is up for this move. Use this estimate to stop searching moves that cannot possibly become the best move in that many playouts. Eventually there will only be one move left, then stop thinking.

```
cutechess-cli -rounds 100 -tournament gauntlet -concurrency 1 -pgnout results.pgn -debug -ratinginterval 1 \
-engine name=lc_test cmd=lc_test arg="--threads=2" arg="--weights=$HOME/lcnetworks/id30_839e" arg="--noponder" arg="--noise" arg="-llc_test.log" stderr=dbg_test.log \
-engine name=lc_next cmd=lc_next arg="--threads=2" arg="--weights=$HOME/lcnetworks/id30_839e" arg="--noponder" arg="--noise"  arg="-llc_next.log" stderr=dbg_next.log \
-each proto=uci tc=40/10+4
```