### PR TITLE
Do not re-launch lczero exec if no new network in self-play games

### DIFF
--- a/go/src/client/main.go
+++ b/go/src/client/main.go
@@ -319,6 +319,7 @@ func train(networkPath string, count int, params []string, restart bool) (string
 		CUR_LCZERO.launch(networkPath, params, true)
 		CUR_LCZERO.askAndWaitForUciOk()
 	}
+	CUR_LCZERO.Pgn = ""
 	num_games := 1
 	train_cmd := fmt.Sprintf("train %v-%v %v\n", pid, count, num_games)
 


### PR DESCRIPTION
So basically when getNetwork is called, we can check if it try to download one or not.

If it didn't download a new network, no need to relaunch lczero.exe which takes about 10s to read the weights (which can be painful for 1080Ti users who take 30s for a single game).

However there are a bit of changes due to the find that cmd.Wait() cannot be used since lczero is not going to stop after the self-play is done, but we still need to catch if it ended in an unexpected way.

So to check if it initialised properly and to check if a training game is over, the client calls "uci" and waits for a "uciok". If while waiting for uciok something happens, and the process is killed, then the exit code is printed out. 

To check if the process has been killed, a goroutine is called with "c.Wait()", setting a boolean to true when it happens.

This was tested on all 4 cases : 
No network at start then network is still there
No network at start then network is deleted
Network at start then network is still there
Network at start then network is deleted 