### PR TITLE
[WIP] History planes transition

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -946,7 +946,8 @@ Network::Netresult Network::get_scored_moves(const BoardHistory& pos, DebugRawDa
     }
 
     NNPlanes planes;
-    gather_features(pos, planes);
+    // Set use_v1_oldflip=true so the game is identical
+    gather_features(pos, planes, true);
     result = get_scored_moves_internal(pos, planes, debug_data);
 
     // Insert result into cache.
@@ -1055,7 +1056,7 @@ void addPieces(const Position* pos, Color side, Network::NNPlanes& planes, int p
   }
 }
 
-void Network::gather_features(const BoardHistory& bh, NNPlanes& planes) {
+void Network::gather_features(const BoardHistory& bh, NNPlanes& planes, bool use_v1_oldflip) {
     Color us = bh.cur().side_to_move();
     Color them = ~us;
     const Position* pos = &bh.cur();
@@ -1073,13 +1074,16 @@ void Network::gather_features(const BoardHistory& bh, NNPlanes& planes) {
     planes.move_count = 0;
 
     int mc = bh.positions.size() - 1;
+    bool flip = us == BLACK;
     for (int i = 0; i < std::min(T_HISTORY, mc + 1); ++i) {
         pos = &bh.positions[mc - i];
 
-        us = pos->side_to_move();
-        them = ~us;
+        if (use_v1_oldflip) {
+            us = pos->side_to_move();
+            them = ~us;
 
-        bool flip = us == BLACK;
+            flip = us == BLACK;
+        }
 
         addPieces<PAWN  >(pos, us, planes, i * 14 + 0, flip);
         addPieces<KNIGHT>(pos, us, planes, i * 14 + 1, flip);

--- a/src/Network.h
+++ b/src/Network.h
@@ -89,7 +89,7 @@ public:
                         float temperature = 1.0f);
 
     static int lookup(Move move);
-    static void gather_features(const BoardHistory& pos, NNPlanes& planes);
+    static void gather_features(const BoardHistory& pos, NNPlanes& planes, bool use_v1_oldflip);
 
 private:
     static std::pair<int, int> load_v1_network(std::ifstream& wtfile);

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -106,7 +106,8 @@ void Training::record(const BoardHistory& state, Move move) {
     auto step = TimeStep{};
     step.to_move = state.cur().side_to_move();
     step.planes = Network::NNPlanes{};
-    Network::gather_features(state, step.planes);
+    // use_v1_oldflip=false so we record new history plane format
+    Network::gather_features(state, step.planes, false);
 
     step.probabilities.resize(Network::NUM_OUTPUT_POLICY);
     step.probabilities[Network::lookup(move)] = 1.0;
@@ -117,7 +118,8 @@ void Training::record(const BoardHistory& state, UCTNode& root) {
     auto step = TimeStep{};
     step.to_move = state.cur().side_to_move();
     step.planes = Network::NNPlanes{};
-    Network::gather_features(state, step.planes);
+    // use_v1_oldflip=false so we record new history plane format
+    Network::gather_features(state, step.planes, false);
 
     auto result = Network::get_scored_moves(state);
     step.net_winrate = result.second;

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -182,8 +182,10 @@ void generate_training_games(istringstream& is) {
     fs::create_directories(dir);
     myprintf_so("Created dirs %s\n", dir.string().c_str());
   }
+  auto chunker_v1 = OutputChunker{dir.string() + "/training_v1", true};
   auto chunker = OutputChunker{dir.string() + "/training", true};
   for (int64_t i = 0; i < num_games; i++) {
+    Training::dump_training(play_one_game(), chunker_v1);
     Training::dump_training_v2(play_one_game(), chunker);
   }
 }


### PR DESCRIPTION
First to curious people, this issue is probably not critical like the move_count. All self-play data, past, present and future is still valid, and we should be able to continue making progress while this issue is being worked on. Simple explanation is the board histories are not oriented the way the Deepmind paper specified, and this makes it a harder for the network to make use of them. But clearly the network is able to play pretty decent chess despite this.

@Error323 @glinscott got a late start on this tonight and only got a tiny bit of work done. 

All I did was create two copies of v1 and v2 data in the old format, and diffed them to verify the game is reproducible. Then I modified the code to send the old format to the network so the game is still identical, but output the new format to the training. Again I ran it twice to make sure the game is the same.

Finally I just glanced at the diff of the v1 old format and the v2 new format. I can see the history planes are different and everything else (policy, value, winner of game) is the same. I haven't looked in detail if the flipping is done correctly yet.

[training.0.gz](https://github.com/glinscott/leela-chess/files/1870247/training.0.gz) - v2 (binary) - use_v1_oldflip=true
[training.4.gz](https://github.com/glinscott/leela-chess/files/1870249/training.4.gz) - v2 (binary) - use_v1_oldflip=false
[training_v1.0.gz](https://github.com/glinscott/leela-chess/files/1870250/training_v1.0.gz) - v1 (text) - use_v1_oldflip=true
[training_v1.4.gz](https://github.com/glinscott/leela-chess/files/1870251/training_v1.4.gz) - v1 (text) - use_v1_oldflip=false
