### PR TITLE
Specify download filename for network file.

### DIFF
--- a/go/src/server/templates/networks.tmpl
+++ b/go/src/server/templates/networks.tmpl
@@ -17,7 +17,7 @@
       {{range .networks}}
       <tr>
         <td>{{.id}}</td>
-        <td><a href="/get_network?sha={{.sha}}">{{.short_sha}}</a></td>
+        <td><a href="/get_network?sha={{.sha}}" download="weights_{{.id}}.txt.gz">{{.short_sha}}</a></td>
         <td>{{.elo}}</td>
         <td>{{.games}}</td>
         <td>{{.blocks}}</td>


### PR DESCRIPTION
E.g. download a new network in firefox currently creates a file called 'get_network'. The dialog does say it is a gzip file, but if you don't notice this, or forget, it's not obvious that you need to unzip the file.

I don't know if the code below is legal syntax, but it would be even better if the Id number could be left-padded to 4 digits or so. Perhaps something like this:
```
<td><a href="/get_network?sha={{.sha}}" 
download="weights_{{printf "%04d" {{.id}} }}.txt.gz">
{{.short_sha}}</a></td>
```
This tries to address #186 but I thought using Id number would be more intuitive for ordinary users than using the SHA. A higher Id means a later weights file. Also, using Id number means that weights files can be ordered by filename, with the highest one being the latest.
