### PR TITLE
Add support to send and store client and engine hashes.

### DIFF
--- a/go/src/client/main.go
+++ b/go/src/client/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -30,9 +31,40 @@ var PASSWORD = flag.String("password", "", "Password")
 var GPU = flag.Int("gpu", -1, "ID of the OpenCL device to use (-1 for default, or no GPU)")
 var DEBUG = flag.Bool("debug", false, "Enable debug mode to see verbose output and save logs")
 
+var clientHash = ""
+var lczeroHash = ""
+
 type Settings struct {
 	User string
 	Pass string
+}
+
+func computeSha(filename string) (string, error) {
+	h := sha256.New()
+	file, err := os.Open(filename)
+	if err != nil {
+		file, err = os.Open(filename + ".exe")
+		if err != nil {
+			return "", err
+		}
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(h, file); err != nil {
+		return "", err
+	}
+	sha := fmt.Sprintf("%x", h.Sum(nil))
+	if len(sha) != 64 {
+		return "", errors.New("Hash length is not 64")
+	}
+	return sha, nil
+}
+
+func initHash() {
+	execPath, _ := os.Executable()
+	clientHash, _ = computeSha(execPath)
+	dir, _ := os.Getwd()
+	lczeroHash, _ = computeSha(path.Join(dir, "lczero"))
 }
 
 /*
@@ -77,6 +109,8 @@ func getExtraParams() map[string]string {
 		"user":     *USER,
 		"password": *PASSWORD,
 		"version":  "4",
+		"selfhash": clientHash,
+		"engineHash": lczeroHash,
 	}
 }
 
@@ -364,6 +398,7 @@ func nextGame(httpClient *http.Client, count int) error {
 }
 
 func main() {
+	initHash()
 	flag.Parse()
 
 	if len(*USER) == 0 || len(*PASSWORD) == 0 {

--- a/go/src/server/db/models.go
+++ b/go/src/server/db/models.go
@@ -77,6 +77,8 @@ type MatchGame struct {
 	Result  int
 	Done    bool
 	Flip    bool
+	ClientSha string
+	EngineSha string
 }
 
 type TrainingGame struct {
@@ -94,4 +96,6 @@ type TrainingGame struct {
 	Path      string
 	Pgn       string
 	Compacted bool
+	ClientSha string
+	EngineSha string
 }

--- a/go/src/server/main.go
+++ b/go/src/server/main.go
@@ -866,8 +866,7 @@ func viewMatch(c *gin.Context) {
 }
 
 func viewTrainingData(c *gin.Context) {
-	// rows, err := db.GetDB().Raw(`SELECT MAX(id) FROM training_games WHERE compacted = true`).Rows()
-	rows, err := db.GetDB().Raw(`SELECT MAX(id) FROM training_games`).Rows()
+	rows, err := db.GetDB().Raw(`SELECT MAX(id) FROM training_games WHERE compacted = true`).Rows()
 	if err != nil {
 		log.Println(err)
 		c.String(500, "Internal error")

--- a/go/src/server/main_test.go
+++ b/go/src/server/main_test.go
@@ -302,8 +302,8 @@ func testMatchResult(s *StoreSuite, promote bool) {
 			"match_game_id": match_game_id,
 			"result":        fmt.Sprintf("%d", result),
 			"pgn":           "asdf",
-		    "selfHash":      "01234567890123456789012345678901234567890123456790123456790123",
-		    "engineHash":    "01234567890123456789012345678901234567890123456790123456790123",
+			"selfHash":      "01234567890123456789012345678901234567890123456790123456790123",
+			"engineHash":    "01234567890123456789012345678901234567890123456790123456790123",
 		}))
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 		s.router.ServeHTTP(s.w, req)

--- a/go/src/server/main_test.go
+++ b/go/src/server/main_test.go
@@ -166,6 +166,8 @@ func (s *StoreSuite) TestUploadGameNewUser() {
 		"training_id": "1",
 		"network_id":  "1",
 		"version":     "1",
+		"selfHash":    "01234567890123456789012345678901234567890123456790123456790123",
+		"engineHash":  "01234567890123456789012345678901234567890123456790123456790123",
 	}
 	tmpfile, _ := ioutil.TempFile("", "example")
 	defer os.Remove(tmpfile.Name())
@@ -300,6 +302,8 @@ func testMatchResult(s *StoreSuite, promote bool) {
 			"match_game_id": match_game_id,
 			"result":        fmt.Sprintf("%d", result),
 			"pgn":           "asdf",
+		    "selfHash":      "01234567890123456789012345678901234567890123456790123456790123",
+		    "engineHash":    "01234567890123456789012345678901234567890123456790123456790123",
 		}))
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 		s.router.ServeHTTP(s.w, req)


### PR DESCRIPTION
This is my work for: #234

I don't have a working database setup, so I can't actually test that this works at runtime... But it compiles! (This is possibly my first time writing go code too...)

Also, I attempted to update main_test.go for the server, but it appears that main.go currently fails go vet, so that didn't get me anywhere.

 