### PR TITLE
Tensorflow C++ implementation of lczero

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Barry Becker
 Nate
 Virgile Andreani
 cheshirecats
+Google LLC

--- a/lc0/.gitignore
+++ b/lc0/.gitignore
@@ -1,0 +1,2 @@
+build/
+testdata/

--- a/lc0/build.sh
+++ b/lc0/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/bash
+
+rm -fr build
+CC=clang CXX=clang++ meson build --buildtype release
+# CC=clang CXX=clang++ meson build --buildtype debugoptimized
+cd build
+ninja

--- a/lc0/meson.build
+++ b/lc0/meson.build
@@ -1,0 +1,64 @@
+project('lc0', 'cpp', 
+        default_options : ['c_std=c17', 'cpp_std=c++17'])
+
+# add_global_arguments('-Wno-macro-redefined', language : 'cpp')
+cc = meson.get_compiler('cpp')
+
+# Installed from https://github.com/FloopCZ/tensorflow_cc
+tensorflow_cc = declare_dependency(
+  include_directories: include_directories(
+    '/usr/local/include/tensorflow',
+    '/usr/local/include/tensorflow/bazel-genfiles',
+    '/usr/local/include/tensorflow/tensorflow/contrib/makefile/downloads',
+    '/usr/local/include/tensorflow/tensorflow/contrib/makefile/downloads/eigen',
+    '/usr/local/include/tensorflow/tensorflow/contrib/makefile/downloads/gemmlowp',
+    '/usr/local/include/tensorflow/tensorflow/contrib/makefile/downloads/nsync/public',
+    '/usr/local/include/tensorflow/tensorflow/contrib/makefile/gen/protobuf-host/include',
+  ),
+  dependencies: [
+      cc.find_library('libtensorflow_cc', dirs: '/usr/local/lib/tensorflow_cc/'),
+      cc.find_library('dl'),
+      cc.find_library('pthread'),
+      cc.find_library('libprotobuf', dirs: '/usr/local/lib/tensorflow_cc/'),
+  ],
+)
+
+deps = []
+deps += tensorflow_cc
+deps += cc.find_library('stdc++fs')
+# deps += dependency('libprofiler')
+
+files = [
+  'src/chess/bitboard.cc',
+  'src/chess/board.cc',
+  'src/neural/loader.cc',
+  'src/neural/network_tf.cc',
+  'src/mcts/search.cc',
+  'src/mcts/node.cc',
+  'src/engine.cc',
+  'src/uciloop.cc',
+  'src/ucioptions.cc',
+  'src/utils/transpose.cc',
+]
+
+includes = []
+includes += include_directories('src')
+
+executable('lc0', 'src/main.cc',
+  files, include_directories: includes, dependencies: deps)
+
+
+### Tests
+
+test_deps = deps
+test_deps += dependency('gtest')
+
+test('ChessBoard',
+  executable('chessboard_test', 'src/chess/board_test.cc',
+  files, include_directories: includes, dependencies: test_deps
+))
+
+test('Network',
+  executable('network_test', 'src/neural/network_test.cc',
+  files, include_directories: includes, dependencies: test_deps
+))

--- a/lc0/src/chess/bitboard.cc
+++ b/lc0/src/chess/bitboard.cc
@@ -1,0 +1,316 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "chess/bitboard.h"
+#include "utils/exception.h"
+
+namespace lczero {
+
+namespace {
+
+const Move kIdxToMove[] = {
+    "a1b1",  "a1c1",  "a1d1",  "a1e1",  "a1f1",  "a1g1",  "a1h1",  "a1a2",
+    "a1b2",  "a1c2",  "a1a3",  "a1b3",  "a1c3",  "a1a4",  "a1d4",  "a1a5",
+    "a1e5",  "a1a6",  "a1f6",  "a1a7",  "a1g7",  "a1a8",  "a1h8",  "b1a1",
+    "b1c1",  "b1d1",  "b1e1",  "b1f1",  "b1g1",  "b1h1",  "b1a2",  "b1b2",
+    "b1c2",  "b1d2",  "b1a3",  "b1b3",  "b1c3",  "b1d3",  "b1b4",  "b1e4",
+    "b1b5",  "b1f5",  "b1b6",  "b1g6",  "b1b7",  "b1h7",  "b1b8",  "c1a1",
+    "c1b1",  "c1d1",  "c1e1",  "c1f1",  "c1g1",  "c1h1",  "c1a2",  "c1b2",
+    "c1c2",  "c1d2",  "c1e2",  "c1a3",  "c1b3",  "c1c3",  "c1d3",  "c1e3",
+    "c1c4",  "c1f4",  "c1c5",  "c1g5",  "c1c6",  "c1h6",  "c1c7",  "c1c8",
+    "d1a1",  "d1b1",  "d1c1",  "d1e1",  "d1f1",  "d1g1",  "d1h1",  "d1b2",
+    "d1c2",  "d1d2",  "d1e2",  "d1f2",  "d1b3",  "d1c3",  "d1d3",  "d1e3",
+    "d1f3",  "d1a4",  "d1d4",  "d1g4",  "d1d5",  "d1h5",  "d1d6",  "d1d7",
+    "d1d8",  "e1a1",  "e1b1",  "e1c1",  "e1d1",  "e1f1",  "e1g1",  "e1h1",
+    "e1c2",  "e1d2",  "e1e2",  "e1f2",  "e1g2",  "e1c3",  "e1d3",  "e1e3",
+    "e1f3",  "e1g3",  "e1b4",  "e1e4",  "e1h4",  "e1a5",  "e1e5",  "e1e6",
+    "e1e7",  "e1e8",  "f1a1",  "f1b1",  "f1c1",  "f1d1",  "f1e1",  "f1g1",
+    "f1h1",  "f1d2",  "f1e2",  "f1f2",  "f1g2",  "f1h2",  "f1d3",  "f1e3",
+    "f1f3",  "f1g3",  "f1h3",  "f1c4",  "f1f4",  "f1b5",  "f1f5",  "f1a6",
+    "f1f6",  "f1f7",  "f1f8",  "g1a1",  "g1b1",  "g1c1",  "g1d1",  "g1e1",
+    "g1f1",  "g1h1",  "g1e2",  "g1f2",  "g1g2",  "g1h2",  "g1e3",  "g1f3",
+    "g1g3",  "g1h3",  "g1d4",  "g1g4",  "g1c5",  "g1g5",  "g1b6",  "g1g6",
+    "g1a7",  "g1g7",  "g1g8",  "h1a1",  "h1b1",  "h1c1",  "h1d1",  "h1e1",
+    "h1f1",  "h1g1",  "h1f2",  "h1g2",  "h1h2",  "h1f3",  "h1g3",  "h1h3",
+    "h1e4",  "h1h4",  "h1d5",  "h1h5",  "h1c6",  "h1h6",  "h1b7",  "h1h7",
+    "h1a8",  "h1h8",  "a2a1",  "a2b1",  "a2c1",  "a2b2",  "a2c2",  "a2d2",
+    "a2e2",  "a2f2",  "a2g2",  "a2h2",  "a2a3",  "a2b3",  "a2c3",  "a2a4",
+    "a2b4",  "a2c4",  "a2a5",  "a2d5",  "a2a6",  "a2e6",  "a2a7",  "a2f7",
+    "a2a8",  "a2g8",  "b2a1",  "b2b1",  "b2c1",  "b2d1",  "b2a2",  "b2c2",
+    "b2d2",  "b2e2",  "b2f2",  "b2g2",  "b2h2",  "b2a3",  "b2b3",  "b2c3",
+    "b2d3",  "b2a4",  "b2b4",  "b2c4",  "b2d4",  "b2b5",  "b2e5",  "b2b6",
+    "b2f6",  "b2b7",  "b2g7",  "b2b8",  "b2h8",  "c2a1",  "c2b1",  "c2c1",
+    "c2d1",  "c2e1",  "c2a2",  "c2b2",  "c2d2",  "c2e2",  "c2f2",  "c2g2",
+    "c2h2",  "c2a3",  "c2b3",  "c2c3",  "c2d3",  "c2e3",  "c2a4",  "c2b4",
+    "c2c4",  "c2d4",  "c2e4",  "c2c5",  "c2f5",  "c2c6",  "c2g6",  "c2c7",
+    "c2h7",  "c2c8",  "d2b1",  "d2c1",  "d2d1",  "d2e1",  "d2f1",  "d2a2",
+    "d2b2",  "d2c2",  "d2e2",  "d2f2",  "d2g2",  "d2h2",  "d2b3",  "d2c3",
+    "d2d3",  "d2e3",  "d2f3",  "d2b4",  "d2c4",  "d2d4",  "d2e4",  "d2f4",
+    "d2a5",  "d2d5",  "d2g5",  "d2d6",  "d2h6",  "d2d7",  "d2d8",  "e2c1",
+    "e2d1",  "e2e1",  "e2f1",  "e2g1",  "e2a2",  "e2b2",  "e2c2",  "e2d2",
+    "e2f2",  "e2g2",  "e2h2",  "e2c3",  "e2d3",  "e2e3",  "e2f3",  "e2g3",
+    "e2c4",  "e2d4",  "e2e4",  "e2f4",  "e2g4",  "e2b5",  "e2e5",  "e2h5",
+    "e2a6",  "e2e6",  "e2e7",  "e2e8",  "f2d1",  "f2e1",  "f2f1",  "f2g1",
+    "f2h1",  "f2a2",  "f2b2",  "f2c2",  "f2d2",  "f2e2",  "f2g2",  "f2h2",
+    "f2d3",  "f2e3",  "f2f3",  "f2g3",  "f2h3",  "f2d4",  "f2e4",  "f2f4",
+    "f2g4",  "f2h4",  "f2c5",  "f2f5",  "f2b6",  "f2f6",  "f2a7",  "f2f7",
+    "f2f8",  "g2e1",  "g2f1",  "g2g1",  "g2h1",  "g2a2",  "g2b2",  "g2c2",
+    "g2d2",  "g2e2",  "g2f2",  "g2h2",  "g2e3",  "g2f3",  "g2g3",  "g2h3",
+    "g2e4",  "g2f4",  "g2g4",  "g2h4",  "g2d5",  "g2g5",  "g2c6",  "g2g6",
+    "g2b7",  "g2g7",  "g2a8",  "g2g8",  "h2f1",  "h2g1",  "h2h1",  "h2a2",
+    "h2b2",  "h2c2",  "h2d2",  "h2e2",  "h2f2",  "h2g2",  "h2f3",  "h2g3",
+    "h2h3",  "h2f4",  "h2g4",  "h2h4",  "h2e5",  "h2h5",  "h2d6",  "h2h6",
+    "h2c7",  "h2h7",  "h2b8",  "h2h8",  "a3a1",  "a3b1",  "a3c1",  "a3a2",
+    "a3b2",  "a3c2",  "a3b3",  "a3c3",  "a3d3",  "a3e3",  "a3f3",  "a3g3",
+    "a3h3",  "a3a4",  "a3b4",  "a3c4",  "a3a5",  "a3b5",  "a3c5",  "a3a6",
+    "a3d6",  "a3a7",  "a3e7",  "a3a8",  "a3f8",  "b3a1",  "b3b1",  "b3c1",
+    "b3d1",  "b3a2",  "b3b2",  "b3c2",  "b3d2",  "b3a3",  "b3c3",  "b3d3",
+    "b3e3",  "b3f3",  "b3g3",  "b3h3",  "b3a4",  "b3b4",  "b3c4",  "b3d4",
+    "b3a5",  "b3b5",  "b3c5",  "b3d5",  "b3b6",  "b3e6",  "b3b7",  "b3f7",
+    "b3b8",  "b3g8",  "c3a1",  "c3b1",  "c3c1",  "c3d1",  "c3e1",  "c3a2",
+    "c3b2",  "c3c2",  "c3d2",  "c3e2",  "c3a3",  "c3b3",  "c3d3",  "c3e3",
+    "c3f3",  "c3g3",  "c3h3",  "c3a4",  "c3b4",  "c3c4",  "c3d4",  "c3e4",
+    "c3a5",  "c3b5",  "c3c5",  "c3d5",  "c3e5",  "c3c6",  "c3f6",  "c3c7",
+    "c3g7",  "c3c8",  "c3h8",  "d3b1",  "d3c1",  "d3d1",  "d3e1",  "d3f1",
+    "d3b2",  "d3c2",  "d3d2",  "d3e2",  "d3f2",  "d3a3",  "d3b3",  "d3c3",
+    "d3e3",  "d3f3",  "d3g3",  "d3h3",  "d3b4",  "d3c4",  "d3d4",  "d3e4",
+    "d3f4",  "d3b5",  "d3c5",  "d3d5",  "d3e5",  "d3f5",  "d3a6",  "d3d6",
+    "d3g6",  "d3d7",  "d3h7",  "d3d8",  "e3c1",  "e3d1",  "e3e1",  "e3f1",
+    "e3g1",  "e3c2",  "e3d2",  "e3e2",  "e3f2",  "e3g2",  "e3a3",  "e3b3",
+    "e3c3",  "e3d3",  "e3f3",  "e3g3",  "e3h3",  "e3c4",  "e3d4",  "e3e4",
+    "e3f4",  "e3g4",  "e3c5",  "e3d5",  "e3e5",  "e3f5",  "e3g5",  "e3b6",
+    "e3e6",  "e3h6",  "e3a7",  "e3e7",  "e3e8",  "f3d1",  "f3e1",  "f3f1",
+    "f3g1",  "f3h1",  "f3d2",  "f3e2",  "f3f2",  "f3g2",  "f3h2",  "f3a3",
+    "f3b3",  "f3c3",  "f3d3",  "f3e3",  "f3g3",  "f3h3",  "f3d4",  "f3e4",
+    "f3f4",  "f3g4",  "f3h4",  "f3d5",  "f3e5",  "f3f5",  "f3g5",  "f3h5",
+    "f3c6",  "f3f6",  "f3b7",  "f3f7",  "f3a8",  "f3f8",  "g3e1",  "g3f1",
+    "g3g1",  "g3h1",  "g3e2",  "g3f2",  "g3g2",  "g3h2",  "g3a3",  "g3b3",
+    "g3c3",  "g3d3",  "g3e3",  "g3f3",  "g3h3",  "g3e4",  "g3f4",  "g3g4",
+    "g3h4",  "g3e5",  "g3f5",  "g3g5",  "g3h5",  "g3d6",  "g3g6",  "g3c7",
+    "g3g7",  "g3b8",  "g3g8",  "h3f1",  "h3g1",  "h3h1",  "h3f2",  "h3g2",
+    "h3h2",  "h3a3",  "h3b3",  "h3c3",  "h3d3",  "h3e3",  "h3f3",  "h3g3",
+    "h3f4",  "h3g4",  "h3h4",  "h3f5",  "h3g5",  "h3h5",  "h3e6",  "h3h6",
+    "h3d7",  "h3h7",  "h3c8",  "h3h8",  "a4a1",  "a4d1",  "a4a2",  "a4b2",
+    "a4c2",  "a4a3",  "a4b3",  "a4c3",  "a4b4",  "a4c4",  "a4d4",  "a4e4",
+    "a4f4",  "a4g4",  "a4h4",  "a4a5",  "a4b5",  "a4c5",  "a4a6",  "a4b6",
+    "a4c6",  "a4a7",  "a4d7",  "a4a8",  "a4e8",  "b4b1",  "b4e1",  "b4a2",
+    "b4b2",  "b4c2",  "b4d2",  "b4a3",  "b4b3",  "b4c3",  "b4d3",  "b4a4",
+    "b4c4",  "b4d4",  "b4e4",  "b4f4",  "b4g4",  "b4h4",  "b4a5",  "b4b5",
+    "b4c5",  "b4d5",  "b4a6",  "b4b6",  "b4c6",  "b4d6",  "b4b7",  "b4e7",
+    "b4b8",  "b4f8",  "c4c1",  "c4f1",  "c4a2",  "c4b2",  "c4c2",  "c4d2",
+    "c4e2",  "c4a3",  "c4b3",  "c4c3",  "c4d3",  "c4e3",  "c4a4",  "c4b4",
+    "c4d4",  "c4e4",  "c4f4",  "c4g4",  "c4h4",  "c4a5",  "c4b5",  "c4c5",
+    "c4d5",  "c4e5",  "c4a6",  "c4b6",  "c4c6",  "c4d6",  "c4e6",  "c4c7",
+    "c4f7",  "c4c8",  "c4g8",  "d4a1",  "d4d1",  "d4g1",  "d4b2",  "d4c2",
+    "d4d2",  "d4e2",  "d4f2",  "d4b3",  "d4c3",  "d4d3",  "d4e3",  "d4f3",
+    "d4a4",  "d4b4",  "d4c4",  "d4e4",  "d4f4",  "d4g4",  "d4h4",  "d4b5",
+    "d4c5",  "d4d5",  "d4e5",  "d4f5",  "d4b6",  "d4c6",  "d4d6",  "d4e6",
+    "d4f6",  "d4a7",  "d4d7",  "d4g7",  "d4d8",  "d4h8",  "e4b1",  "e4e1",
+    "e4h1",  "e4c2",  "e4d2",  "e4e2",  "e4f2",  "e4g2",  "e4c3",  "e4d3",
+    "e4e3",  "e4f3",  "e4g3",  "e4a4",  "e4b4",  "e4c4",  "e4d4",  "e4f4",
+    "e4g4",  "e4h4",  "e4c5",  "e4d5",  "e4e5",  "e4f5",  "e4g5",  "e4c6",
+    "e4d6",  "e4e6",  "e4f6",  "e4g6",  "e4b7",  "e4e7",  "e4h7",  "e4a8",
+    "e4e8",  "f4c1",  "f4f1",  "f4d2",  "f4e2",  "f4f2",  "f4g2",  "f4h2",
+    "f4d3",  "f4e3",  "f4f3",  "f4g3",  "f4h3",  "f4a4",  "f4b4",  "f4c4",
+    "f4d4",  "f4e4",  "f4g4",  "f4h4",  "f4d5",  "f4e5",  "f4f5",  "f4g5",
+    "f4h5",  "f4d6",  "f4e6",  "f4f6",  "f4g6",  "f4h6",  "f4c7",  "f4f7",
+    "f4b8",  "f4f8",  "g4d1",  "g4g1",  "g4e2",  "g4f2",  "g4g2",  "g4h2",
+    "g4e3",  "g4f3",  "g4g3",  "g4h3",  "g4a4",  "g4b4",  "g4c4",  "g4d4",
+    "g4e4",  "g4f4",  "g4h4",  "g4e5",  "g4f5",  "g4g5",  "g4h5",  "g4e6",
+    "g4f6",  "g4g6",  "g4h6",  "g4d7",  "g4g7",  "g4c8",  "g4g8",  "h4e1",
+    "h4h1",  "h4f2",  "h4g2",  "h4h2",  "h4f3",  "h4g3",  "h4h3",  "h4a4",
+    "h4b4",  "h4c4",  "h4d4",  "h4e4",  "h4f4",  "h4g4",  "h4f5",  "h4g5",
+    "h4h5",  "h4f6",  "h4g6",  "h4h6",  "h4e7",  "h4h7",  "h4d8",  "h4h8",
+    "a5a1",  "a5e1",  "a5a2",  "a5d2",  "a5a3",  "a5b3",  "a5c3",  "a5a4",
+    "a5b4",  "a5c4",  "a5b5",  "a5c5",  "a5d5",  "a5e5",  "a5f5",  "a5g5",
+    "a5h5",  "a5a6",  "a5b6",  "a5c6",  "a5a7",  "a5b7",  "a5c7",  "a5a8",
+    "a5d8",  "b5b1",  "b5f1",  "b5b2",  "b5e2",  "b5a3",  "b5b3",  "b5c3",
+    "b5d3",  "b5a4",  "b5b4",  "b5c4",  "b5d4",  "b5a5",  "b5c5",  "b5d5",
+    "b5e5",  "b5f5",  "b5g5",  "b5h5",  "b5a6",  "b5b6",  "b5c6",  "b5d6",
+    "b5a7",  "b5b7",  "b5c7",  "b5d7",  "b5b8",  "b5e8",  "c5c1",  "c5g1",
+    "c5c2",  "c5f2",  "c5a3",  "c5b3",  "c5c3",  "c5d3",  "c5e3",  "c5a4",
+    "c5b4",  "c5c4",  "c5d4",  "c5e4",  "c5a5",  "c5b5",  "c5d5",  "c5e5",
+    "c5f5",  "c5g5",  "c5h5",  "c5a6",  "c5b6",  "c5c6",  "c5d6",  "c5e6",
+    "c5a7",  "c5b7",  "c5c7",  "c5d7",  "c5e7",  "c5c8",  "c5f8",  "d5d1",
+    "d5h1",  "d5a2",  "d5d2",  "d5g2",  "d5b3",  "d5c3",  "d5d3",  "d5e3",
+    "d5f3",  "d5b4",  "d5c4",  "d5d4",  "d5e4",  "d5f4",  "d5a5",  "d5b5",
+    "d5c5",  "d5e5",  "d5f5",  "d5g5",  "d5h5",  "d5b6",  "d5c6",  "d5d6",
+    "d5e6",  "d5f6",  "d5b7",  "d5c7",  "d5d7",  "d5e7",  "d5f7",  "d5a8",
+    "d5d8",  "d5g8",  "e5a1",  "e5e1",  "e5b2",  "e5e2",  "e5h2",  "e5c3",
+    "e5d3",  "e5e3",  "e5f3",  "e5g3",  "e5c4",  "e5d4",  "e5e4",  "e5f4",
+    "e5g4",  "e5a5",  "e5b5",  "e5c5",  "e5d5",  "e5f5",  "e5g5",  "e5h5",
+    "e5c6",  "e5d6",  "e5e6",  "e5f6",  "e5g6",  "e5c7",  "e5d7",  "e5e7",
+    "e5f7",  "e5g7",  "e5b8",  "e5e8",  "e5h8",  "f5b1",  "f5f1",  "f5c2",
+    "f5f2",  "f5d3",  "f5e3",  "f5f3",  "f5g3",  "f5h3",  "f5d4",  "f5e4",
+    "f5f4",  "f5g4",  "f5h4",  "f5a5",  "f5b5",  "f5c5",  "f5d5",  "f5e5",
+    "f5g5",  "f5h5",  "f5d6",  "f5e6",  "f5f6",  "f5g6",  "f5h6",  "f5d7",
+    "f5e7",  "f5f7",  "f5g7",  "f5h7",  "f5c8",  "f5f8",  "g5c1",  "g5g1",
+    "g5d2",  "g5g2",  "g5e3",  "g5f3",  "g5g3",  "g5h3",  "g5e4",  "g5f4",
+    "g5g4",  "g5h4",  "g5a5",  "g5b5",  "g5c5",  "g5d5",  "g5e5",  "g5f5",
+    "g5h5",  "g5e6",  "g5f6",  "g5g6",  "g5h6",  "g5e7",  "g5f7",  "g5g7",
+    "g5h7",  "g5d8",  "g5g8",  "h5d1",  "h5h1",  "h5e2",  "h5h2",  "h5f3",
+    "h5g3",  "h5h3",  "h5f4",  "h5g4",  "h5h4",  "h5a5",  "h5b5",  "h5c5",
+    "h5d5",  "h5e5",  "h5f5",  "h5g5",  "h5f6",  "h5g6",  "h5h6",  "h5f7",
+    "h5g7",  "h5h7",  "h5e8",  "h5h8",  "a6a1",  "a6f1",  "a6a2",  "a6e2",
+    "a6a3",  "a6d3",  "a6a4",  "a6b4",  "a6c4",  "a6a5",  "a6b5",  "a6c5",
+    "a6b6",  "a6c6",  "a6d6",  "a6e6",  "a6f6",  "a6g6",  "a6h6",  "a6a7",
+    "a6b7",  "a6c7",  "a6a8",  "a6b8",  "a6c8",  "b6b1",  "b6g1",  "b6b2",
+    "b6f2",  "b6b3",  "b6e3",  "b6a4",  "b6b4",  "b6c4",  "b6d4",  "b6a5",
+    "b6b5",  "b6c5",  "b6d5",  "b6a6",  "b6c6",  "b6d6",  "b6e6",  "b6f6",
+    "b6g6",  "b6h6",  "b6a7",  "b6b7",  "b6c7",  "b6d7",  "b6a8",  "b6b8",
+    "b6c8",  "b6d8",  "c6c1",  "c6h1",  "c6c2",  "c6g2",  "c6c3",  "c6f3",
+    "c6a4",  "c6b4",  "c6c4",  "c6d4",  "c6e4",  "c6a5",  "c6b5",  "c6c5",
+    "c6d5",  "c6e5",  "c6a6",  "c6b6",  "c6d6",  "c6e6",  "c6f6",  "c6g6",
+    "c6h6",  "c6a7",  "c6b7",  "c6c7",  "c6d7",  "c6e7",  "c6a8",  "c6b8",
+    "c6c8",  "c6d8",  "c6e8",  "d6d1",  "d6d2",  "d6h2",  "d6a3",  "d6d3",
+    "d6g3",  "d6b4",  "d6c4",  "d6d4",  "d6e4",  "d6f4",  "d6b5",  "d6c5",
+    "d6d5",  "d6e5",  "d6f5",  "d6a6",  "d6b6",  "d6c6",  "d6e6",  "d6f6",
+    "d6g6",  "d6h6",  "d6b7",  "d6c7",  "d6d7",  "d6e7",  "d6f7",  "d6b8",
+    "d6c8",  "d6d8",  "d6e8",  "d6f8",  "e6e1",  "e6a2",  "e6e2",  "e6b3",
+    "e6e3",  "e6h3",  "e6c4",  "e6d4",  "e6e4",  "e6f4",  "e6g4",  "e6c5",
+    "e6d5",  "e6e5",  "e6f5",  "e6g5",  "e6a6",  "e6b6",  "e6c6",  "e6d6",
+    "e6f6",  "e6g6",  "e6h6",  "e6c7",  "e6d7",  "e6e7",  "e6f7",  "e6g7",
+    "e6c8",  "e6d8",  "e6e8",  "e6f8",  "e6g8",  "f6a1",  "f6f1",  "f6b2",
+    "f6f2",  "f6c3",  "f6f3",  "f6d4",  "f6e4",  "f6f4",  "f6g4",  "f6h4",
+    "f6d5",  "f6e5",  "f6f5",  "f6g5",  "f6h5",  "f6a6",  "f6b6",  "f6c6",
+    "f6d6",  "f6e6",  "f6g6",  "f6h6",  "f6d7",  "f6e7",  "f6f7",  "f6g7",
+    "f6h7",  "f6d8",  "f6e8",  "f6f8",  "f6g8",  "f6h8",  "g6b1",  "g6g1",
+    "g6c2",  "g6g2",  "g6d3",  "g6g3",  "g6e4",  "g6f4",  "g6g4",  "g6h4",
+    "g6e5",  "g6f5",  "g6g5",  "g6h5",  "g6a6",  "g6b6",  "g6c6",  "g6d6",
+    "g6e6",  "g6f6",  "g6h6",  "g6e7",  "g6f7",  "g6g7",  "g6h7",  "g6e8",
+    "g6f8",  "g6g8",  "g6h8",  "h6c1",  "h6h1",  "h6d2",  "h6h2",  "h6e3",
+    "h6h3",  "h6f4",  "h6g4",  "h6h4",  "h6f5",  "h6g5",  "h6h5",  "h6a6",
+    "h6b6",  "h6c6",  "h6d6",  "h6e6",  "h6f6",  "h6g6",  "h6f7",  "h6g7",
+    "h6h7",  "h6f8",  "h6g8",  "h6h8",  "a7a1",  "a7g1",  "a7a2",  "a7f2",
+    "a7a3",  "a7e3",  "a7a4",  "a7d4",  "a7a5",  "a7b5",  "a7c5",  "a7a6",
+    "a7b6",  "a7c6",  "a7b7",  "a7c7",  "a7d7",  "a7e7",  "a7f7",  "a7g7",
+    "a7h7",  "a7a8",  "a7b8",  "a7c8",  "b7b1",  "b7h1",  "b7b2",  "b7g2",
+    "b7b3",  "b7f3",  "b7b4",  "b7e4",  "b7a5",  "b7b5",  "b7c5",  "b7d5",
+    "b7a6",  "b7b6",  "b7c6",  "b7d6",  "b7a7",  "b7c7",  "b7d7",  "b7e7",
+    "b7f7",  "b7g7",  "b7h7",  "b7a8",  "b7b8",  "b7c8",  "b7d8",  "c7c1",
+    "c7c2",  "c7h2",  "c7c3",  "c7g3",  "c7c4",  "c7f4",  "c7a5",  "c7b5",
+    "c7c5",  "c7d5",  "c7e5",  "c7a6",  "c7b6",  "c7c6",  "c7d6",  "c7e6",
+    "c7a7",  "c7b7",  "c7d7",  "c7e7",  "c7f7",  "c7g7",  "c7h7",  "c7a8",
+    "c7b8",  "c7c8",  "c7d8",  "c7e8",  "d7d1",  "d7d2",  "d7d3",  "d7h3",
+    "d7a4",  "d7d4",  "d7g4",  "d7b5",  "d7c5",  "d7d5",  "d7e5",  "d7f5",
+    "d7b6",  "d7c6",  "d7d6",  "d7e6",  "d7f6",  "d7a7",  "d7b7",  "d7c7",
+    "d7e7",  "d7f7",  "d7g7",  "d7h7",  "d7b8",  "d7c8",  "d7d8",  "d7e8",
+    "d7f8",  "e7e1",  "e7e2",  "e7a3",  "e7e3",  "e7b4",  "e7e4",  "e7h4",
+    "e7c5",  "e7d5",  "e7e5",  "e7f5",  "e7g5",  "e7c6",  "e7d6",  "e7e6",
+    "e7f6",  "e7g6",  "e7a7",  "e7b7",  "e7c7",  "e7d7",  "e7f7",  "e7g7",
+    "e7h7",  "e7c8",  "e7d8",  "e7e8",  "e7f8",  "e7g8",  "f7f1",  "f7a2",
+    "f7f2",  "f7b3",  "f7f3",  "f7c4",  "f7f4",  "f7d5",  "f7e5",  "f7f5",
+    "f7g5",  "f7h5",  "f7d6",  "f7e6",  "f7f6",  "f7g6",  "f7h6",  "f7a7",
+    "f7b7",  "f7c7",  "f7d7",  "f7e7",  "f7g7",  "f7h7",  "f7d8",  "f7e8",
+    "f7f8",  "f7g8",  "f7h8",  "g7a1",  "g7g1",  "g7b2",  "g7g2",  "g7c3",
+    "g7g3",  "g7d4",  "g7g4",  "g7e5",  "g7f5",  "g7g5",  "g7h5",  "g7e6",
+    "g7f6",  "g7g6",  "g7h6",  "g7a7",  "g7b7",  "g7c7",  "g7d7",  "g7e7",
+    "g7f7",  "g7h7",  "g7e8",  "g7f8",  "g7g8",  "g7h8",  "h7b1",  "h7h1",
+    "h7c2",  "h7h2",  "h7d3",  "h7h3",  "h7e4",  "h7h4",  "h7f5",  "h7g5",
+    "h7h5",  "h7f6",  "h7g6",  "h7h6",  "h7a7",  "h7b7",  "h7c7",  "h7d7",
+    "h7e7",  "h7f7",  "h7g7",  "h7f8",  "h7g8",  "h7h8",  "a8a1",  "a8h1",
+    "a8a2",  "a8g2",  "a8a3",  "a8f3",  "a8a4",  "a8e4",  "a8a5",  "a8d5",
+    "a8a6",  "a8b6",  "a8c6",  "a8a7",  "a8b7",  "a8c7",  "a8b8",  "a8c8",
+    "a8d8",  "a8e8",  "a8f8",  "a8g8",  "a8h8",  "b8b1",  "b8b2",  "b8h2",
+    "b8b3",  "b8g3",  "b8b4",  "b8f4",  "b8b5",  "b8e5",  "b8a6",  "b8b6",
+    "b8c6",  "b8d6",  "b8a7",  "b8b7",  "b8c7",  "b8d7",  "b8a8",  "b8c8",
+    "b8d8",  "b8e8",  "b8f8",  "b8g8",  "b8h8",  "c8c1",  "c8c2",  "c8c3",
+    "c8h3",  "c8c4",  "c8g4",  "c8c5",  "c8f5",  "c8a6",  "c8b6",  "c8c6",
+    "c8d6",  "c8e6",  "c8a7",  "c8b7",  "c8c7",  "c8d7",  "c8e7",  "c8a8",
+    "c8b8",  "c8d8",  "c8e8",  "c8f8",  "c8g8",  "c8h8",  "d8d1",  "d8d2",
+    "d8d3",  "d8d4",  "d8h4",  "d8a5",  "d8d5",  "d8g5",  "d8b6",  "d8c6",
+    "d8d6",  "d8e6",  "d8f6",  "d8b7",  "d8c7",  "d8d7",  "d8e7",  "d8f7",
+    "d8a8",  "d8b8",  "d8c8",  "d8e8",  "d8f8",  "d8g8",  "d8h8",  "e8e1",
+    "e8e2",  "e8e3",  "e8a4",  "e8e4",  "e8b5",  "e8e5",  "e8h5",  "e8c6",
+    "e8d6",  "e8e6",  "e8f6",  "e8g6",  "e8c7",  "e8d7",  "e8e7",  "e8f7",
+    "e8g7",  "e8a8",  "e8b8",  "e8c8",  "e8d8",  "e8f8",  "e8g8",  "e8h8",
+    "f8f1",  "f8f2",  "f8a3",  "f8f3",  "f8b4",  "f8f4",  "f8c5",  "f8f5",
+    "f8d6",  "f8e6",  "f8f6",  "f8g6",  "f8h6",  "f8d7",  "f8e7",  "f8f7",
+    "f8g7",  "f8h7",  "f8a8",  "f8b8",  "f8c8",  "f8d8",  "f8e8",  "f8g8",
+    "f8h8",  "g8g1",  "g8a2",  "g8g2",  "g8b3",  "g8g3",  "g8c4",  "g8g4",
+    "g8d5",  "g8g5",  "g8e6",  "g8f6",  "g8g6",  "g8h6",  "g8e7",  "g8f7",
+    "g8g7",  "g8h7",  "g8a8",  "g8b8",  "g8c8",  "g8d8",  "g8e8",  "g8f8",
+    "g8h8",  "h8a1",  "h8h1",  "h8b2",  "h8h2",  "h8c3",  "h8h3",  "h8d4",
+    "h8h4",  "h8e5",  "h8h5",  "h8f6",  "h8g6",  "h8h6",  "h8f7",  "h8g7",
+    "h8h7",  "h8a8",  "h8b8",  "h8c8",  "h8d8",  "h8e8",  "h8f8",  "h8g8",
+    "a7a8q", "a7a8r", "a7a8b", "a7b8q", "a7b8r", "a7b8b", "b7a8q", "b7a8r",
+    "b7a8b", "b7b8q", "b7b8r", "b7b8b", "b7c8q", "b7c8r", "b7c8b", "c7b8q",
+    "c7b8r", "c7b8b", "c7c8q", "c7c8r", "c7c8b", "c7d8q", "c7d8r", "c7d8b",
+    "d7c8q", "d7c8r", "d7c8b", "d7d8q", "d7d8r", "d7d8b", "d7e8q", "d7e8r",
+    "d7e8b", "e7d8q", "e7d8r", "e7d8b", "e7e8q", "e7e8r", "e7e8b", "e7f8q",
+    "e7f8r", "e7f8b", "f7e8q", "f7e8r", "f7e8b", "f7f8q", "f7f8r", "f7f8b",
+    "f7g8q", "f7g8r", "f7g8b", "g7f8q", "g7f8r", "g7f8b", "g7g8q", "g7g8r",
+    "g7g8b", "g7h8q", "g7h8r", "g7h8b", "h7g8q", "h7g8r", "h7g8b", "h7h8q",
+    "h7h8r", "h7h8b", "a2a1q", "a2a1r", "a2a1b", "a2b1q", "a2b1r", "a2b1b",
+    "b2a1q", "b2a1r", "b2a1b", "b2b1q", "b2b1r", "b2b1b", "b2c1q", "b2c1r",
+    "b2c1b", "c2b1q", "c2b1r", "c2b1b", "c2c1q", "c2c1r", "c2c1b", "c2d1q",
+    "c2d1r", "c2d1b", "d2c1q", "d2c1r", "d2c1b", "d2d1q", "d2d1r", "d2d1b",
+    "d2e1q", "d2e1r", "d2e1b", "e2d1q", "e2d1r", "e2d1b", "e2e1q", "e2e1r",
+    "e2e1b", "e2f1q", "e2f1r", "e2f1b", "f2e1q", "f2e1r", "f2e1b", "f2f1q",
+    "f2f1r", "f2f1b", "f2g1q", "f2g1r", "f2g1b", "g2f1q", "g2f1r", "g2f1b",
+    "g2g1q", "g2g1r", "g2g1b", "g2h1q", "g2h1r", "g2h1b", "h2g1q", "h2g1r",
+    "h2g1b", "h2h1q", "h2h1r", "h2h1b"};
+
+std::vector<unsigned short> BuildMoveIndices() {
+  std::vector<unsigned short> res(4 * 64 * 64);
+  for (int i = 0; i < sizeof(kIdxToMove) / sizeof(kIdxToMove[0]); ++i) {
+    res[kIdxToMove[i].as_packed_int()] = i;
+  }
+  return res;
+}
+
+const std::vector<unsigned short> kMoveToIdx = BuildMoveIndices();
+}  // namespace
+
+Move::Move(const std::string& str, bool black) {
+  if (str.size() < 4) throw Exception("Bad move: " + str);
+  from_ = BoardSquare(str.substr(0, 2), black);
+  to_ = BoardSquare(str.substr(2, 2), black);
+  if (str.size() != 4) {
+    if (str.size() != 5) throw Exception("Bad move: " + str);
+    switch (str[4]) {
+      case 'q':
+        promotion_ = Promotion::Queen;
+        break;
+      case 'r':
+        promotion_ = Promotion::Rook;
+        break;
+      case 'b':
+        promotion_ = Promotion::Bishop;
+        break;
+      case 'n':
+        promotion_ = Promotion::Knight;
+        break;
+      default:
+        throw Exception("Bad move: " + str);
+    }
+  }
+}
+
+uint16_t Move::as_packed_int() const {
+  if (promotion_ == Promotion::Knight) {
+    return from_.as_int() * 64 + to_.as_int();
+  } else {
+    return static_cast<int>(promotion_) * 64 * 64 + from_.as_int() * 64 +
+           to_.as_int();
+  }
+}
+
+uint16_t Move::as_nn_index() const { return kMoveToIdx[as_packed_int()]; }
+
+}  // namespace lczero

--- a/lc0/src/chess/bitboard.h
+++ b/lc0/src/chess/bitboard.h
@@ -1,0 +1,245 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "utils/bititer.h"
+
+namespace lczero {
+
+// Stores a coordinates of a single square.
+class BoardSquare {
+ public:
+  constexpr BoardSquare() {}
+  // As a single number, 0 to 63, bottom to top, left to right.
+  // 0 is a1, 8 is b1, 63 is h7.
+  constexpr BoardSquare(std::uint8_t num) : square_(num) {}
+  // From row(bottom to top), and col(left to right), 0-based.
+  constexpr BoardSquare(int row, int col) : BoardSquare(row * 8 + col) {}
+  // From Square name, e.g e4. Only lowercase.
+  constexpr BoardSquare(const std::string& str, bool black = false)
+      : BoardSquare(black ? '8' - str[1] : str[1] - '1', str[0] - 'a') {}
+  constexpr std::uint8_t as_int() const { return square_; }
+  void set(int row, int col) { square_ = row * 8 + col; }
+
+  // 0-based, bottom to top.
+  int row() const { return square_ / 8; }
+  // 0-based, left to right.
+  int col() const { return square_ % 8; }
+
+  // Row := 7 - row.  Col remains the same.
+  void Mirror() { square_ = square_ ^ 0b111000; }
+
+  // Checks whether coordinate is within 0..7.
+  static bool IsValidCoord(int x) { return x >= 0 && x < 8; }
+
+  // Checks whether coordinates are within 0..7.
+  static bool IsValid(int row, int col) {
+    return row >= 0 && col >= 0 && row < 8 && col < 8;
+  }
+
+  constexpr bool operator==(const BoardSquare& other) const {
+    return square_ == other.square_;
+  }
+
+  constexpr bool operator!=(const BoardSquare& other) const {
+    return square_ != other.square_;
+  }
+
+  // Returns the square in algebraic notation (e.g. "e4").
+  std::string as_string() const {
+    return std::string(1, 'a' + col()) + std::string(1, '1' + row());
+  }
+
+ private:
+  std::uint8_t square_ = 0;
+};
+
+// Represents a board as an array of 64 bits.
+// Bit enumeration goes from bottom to top, from left to right:
+// Square a1 is bit 0, square a8 is bit 7, square b1 is bit 8.
+class BitBoard {
+ public:
+  constexpr BitBoard(std::uint64_t board) : board_(board) {}
+  BitBoard() = default;
+  BitBoard(const BitBoard&) = default;
+
+  std::uint64_t as_int() const { return board_; }
+  void clear() { board_ = 0; }
+
+  // Sets the value for given square to 1 if cond is true.
+  // Otherwise does nothing (doesn't reset!).
+  void set_if(BoardSquare square, bool cond) { set_if(square.as_int(), cond); }
+  void set_if(std::uint8_t pos, bool cond) {
+    board_ |= (std::uint64_t(cond) << pos);
+  }
+  void set_if(int row, int col, bool cond) {
+    set_if(BoardSquare(row, col), cond);
+  }
+
+  // Sets value of given square to 1.
+  void set(BoardSquare square) { set(square.as_int()); }
+  void set(std::uint8_t pos) { board_ |= (std::uint64_t(1) << pos); }
+  void set(int row, int col) { set(BoardSquare(row, col)); }
+
+  // Sets value of given square to 0.
+  void reset(BoardSquare square) { reset(square.as_int()); }
+  void reset(std ::uint8_t pos) { board_ &= ~(std::uint64_t(1) << pos); }
+  void reset(int row, int col) { reset(BoardSquare(row, col)); }
+
+  // Gets value of a square.
+  bool get(BoardSquare square) const { return get(square.as_int()); }
+  bool get(std::uint8_t pos) const {
+    return board_ & (std::uint64_t(1) << pos);
+  }
+  bool get(int row, int col) const { return get(BoardSquare(row, col)); }
+
+  // Returns whether all bits of a board are set to 0.
+  bool empty() const { return board_ == 0; }
+
+  // Checks whether two bitboards have common bits set.
+  bool intersects(const BitBoard& other) const { return board_ & other.board_; }
+
+  // Flips black and white side of a board.
+  void Mirror() {
+    board_ = (board_ & 0x00000000FFFFFFFF) << 32 |
+             (board_ & 0xFFFFFFFF00000000) >> 32;
+    board_ = (board_ & 0x0000FFFF0000FFFF) << 16 |
+             (board_ & 0xFFFF0000FFFF0000) >> 16;
+    board_ =
+        (board_ & 0x00FF00FF00FF00FF) << 8 | (board_ & 0xFF00FF00FF00FF00) >> 8;
+  }
+
+  bool operator==(const BitBoard& other) const {
+    return board_ == other.board_;
+  }
+
+  BitIterator<BoardSquare> begin() const { return board_; }
+  BitIterator<BoardSquare> end() const { return 0; }
+
+  std::string DebugString() const {
+    std::string res;
+    for (int i = 7; i >= 0; --i) {
+      for (int j = 0; j < 8; ++j) {
+        if (get(i, j))
+          res += '#';
+        else
+          res += '.';
+      }
+      res += '\n';
+    }
+    return res;
+  }
+
+  // Applies a mask to the bitboard (intersects).
+  BitBoard& operator*=(const BitBoard& a) {
+    board_ &= a.board_;
+    return *this;
+  }
+
+  friend void swap(BitBoard& a, BitBoard& b) {
+    using std::swap;
+    swap(a.board_, b.board_);
+  }
+
+  // Returns union (bitwise OR) of two boards.
+  friend BitBoard operator+(const BitBoard& a, const BitBoard& b) {
+    return {a.board_ | b.board_};
+  }
+
+  // Returns bitboard with one bit reset.
+  friend BitBoard operator-(const BitBoard& a, const BoardSquare& b) {
+    return {a.board_ & ~(1ULL << b.as_int())};
+  }
+
+  // Returns difference (bitwise AND-NOT) of two boards.
+  friend BitBoard operator-(const BitBoard& a, const BitBoard& b) {
+    return {a.board_ & ~b.board_};
+  }
+
+  // Returns intersection (bitwise AND) of two boards.
+  friend BitBoard operator*(const BitBoard& a, const BitBoard& b) {
+    return {a.board_ & b.board_};
+  }
+
+ private:
+  std::uint64_t board_ = 0;
+};
+
+class Move {
+ public:
+  enum class Promotion : std::uint8_t { None, Queen, Rook, Bishop, Knight };
+  Move() = default;
+  Move(BoardSquare from, BoardSquare to) : from_(from), to_(to) {}
+  Move(BoardSquare from, BoardSquare to, Promotion promotion)
+      : from_(from), to_(to), promotion_(promotion) {}
+  Move(const std::string& str, bool black = false);
+  Move(const char* str, bool black = false) : Move(std::string(str), black) {}
+
+  BoardSquare from() const { return from_; }
+  BoardSquare to() const { return to_; }
+  Promotion promotion() const { return promotion_; }
+
+  // 0 .. 16384, knight promotion and no promotion is the same.
+  uint16_t as_packed_int() const;
+
+  // 0 .. 1923, to use in neural networks.
+  uint16_t as_nn_index() const;
+
+  bool operator==(const Move& other) const {
+    return from_ == other.from_ && to_ == other.to_ &&
+           promotion_ == other.promotion_;
+  }
+
+  bool operator!=(const Move& other) const { return !operator==(other); }
+  operator bool() const { return from_.as_int() != 0 || to_.as_int() != 0; }
+
+  void Mirror() {
+    from_.Mirror();
+    to_.Mirror();
+  }
+
+  std::string as_string() const {
+    std::string res = from_.as_string() + to_.as_string();
+    switch (promotion_) {
+      case Promotion::None:
+        return res;
+      case Promotion::Queen:
+        return res + 'q';
+      case Promotion::Rook:
+        return res + 'r';
+      case Promotion::Bishop:
+        return res + 'b';
+      case Promotion::Knight:
+        return res + 'n';
+    }
+  }
+
+ private:
+  BoardSquare from_;
+  BoardSquare to_;
+  Promotion promotion_ = Promotion::None;
+};
+
+using MoveList = std::vector<Move>;
+
+}  // namespace lczero

--- a/lc0/src/chess/board.cc
+++ b/lc0/src/chess/board.cc
@@ -1,0 +1,671 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "chess/board.h"
+
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <sstream>
+#include "utils/exception.h"
+
+namespace lczero {
+
+using std::string;
+
+const string ChessBoard::kStartingFen =
+    "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+void ChessBoard::Clear() { std::memset(this, 0, sizeof(ChessBoard)); }
+
+void ChessBoard::Mirror() {
+  our_pieces_.Mirror();
+  their_pieces_.Mirror();
+  std::swap(our_pieces_, their_pieces_);
+  rooks_.Mirror();
+  bishops_.Mirror();
+  pawns_.Mirror();
+  our_king_.Mirror();
+  their_king_.Mirror();
+  std::swap(our_king_, their_king_);
+  castlings_.Mirror();
+  flipped_ = !flipped_;
+}
+
+namespace {
+static const std::pair<int, int> kKingMoves[] = {
+    {-1, -1}, {-1, 0}, {-1, 1}, {0, -1}, {0, 1}, {1, -1}, {1, 0}, {1, 1}};
+
+static const std::pair<int, int> kRookDirections[] = {
+    {1, 0}, {-1, 0}, {0, 1}, {0, -1}};
+
+static const std::pair<int, int> kBishopDirections[] = {
+    {1, 1}, {-1, 1}, {1, -1}, {-1, -1}};
+
+// If those squares are attacked, king cannot castle.
+static const int k00Attackers[] = {4, 5, 6};
+static const int k000Attackers[] = {2, 3, 4};
+
+// Which squares can rook attack from every of squares.
+static const BitBoard kRookAttacks[] = {
+    0x01010101010101FEULL, 0x02020202020202FDULL, 0x04040404040404FBULL,
+    0x08080808080808F7ULL, 0x10101010101010EFULL, 0x20202020202020DFULL,
+    0x40404040404040BFULL, 0x808080808080807FULL, 0x010101010101FE01ULL,
+    0x020202020202FD02ULL, 0x040404040404FB04ULL, 0x080808080808F708ULL,
+    0x101010101010EF10ULL, 0x202020202020DF20ULL, 0x404040404040BF40ULL,
+    0x8080808080807F80ULL, 0x0101010101FE0101ULL, 0x0202020202FD0202ULL,
+    0x0404040404FB0404ULL, 0x0808080808F70808ULL, 0x1010101010EF1010ULL,
+    0x2020202020DF2020ULL, 0x4040404040BF4040ULL, 0x80808080807F8080ULL,
+    0x01010101FE010101ULL, 0x02020202FD020202ULL, 0x04040404FB040404ULL,
+    0x08080808F7080808ULL, 0x10101010EF101010ULL, 0x20202020DF202020ULL,
+    0x40404040BF404040ULL, 0x808080807F808080ULL, 0x010101FE01010101ULL,
+    0x020202FD02020202ULL, 0x040404FB04040404ULL, 0x080808F708080808ULL,
+    0x101010EF10101010ULL, 0x202020DF20202020ULL, 0x404040BF40404040ULL,
+    0x8080807F80808080ULL, 0x0101FE0101010101ULL, 0x0202FD0202020202ULL,
+    0x0404FB0404040404ULL, 0x0808F70808080808ULL, 0x1010EF1010101010ULL,
+    0x2020DF2020202020ULL, 0x4040BF4040404040ULL, 0x80807F8080808080ULL,
+    0x01FE010101010101ULL, 0x02FD020202020202ULL, 0x04FB040404040404ULL,
+    0x08F7080808080808ULL, 0x10EF101010101010ULL, 0x20DF202020202020ULL,
+    0x40BF404040404040ULL, 0x807F808080808080ULL, 0xFE01010101010101ULL,
+    0xFD02020202020202ULL, 0xFB04040404040404ULL, 0xF708080808080808ULL,
+    0xEF10101010101010ULL, 0xDF20202020202020ULL, 0xBF40404040404040ULL,
+    0x7F80808080808080ULL};
+// Which squares can bishop attack.
+static const BitBoard kBishopAttacks[] = {
+    0x8040201008040200ULL, 0x0080402010080500ULL, 0x0000804020110A00ULL,
+    0x0000008041221400ULL, 0x0000000182442800ULL, 0x0000010204885000ULL,
+    0x000102040810A000ULL, 0x0102040810204000ULL, 0x4020100804020002ULL,
+    0x8040201008050005ULL, 0x00804020110A000AULL, 0x0000804122140014ULL,
+    0x0000018244280028ULL, 0x0001020488500050ULL, 0x0102040810A000A0ULL,
+    0x0204081020400040ULL, 0x2010080402000204ULL, 0x4020100805000508ULL,
+    0x804020110A000A11ULL, 0x0080412214001422ULL, 0x0001824428002844ULL,
+    0x0102048850005088ULL, 0x02040810A000A010ULL, 0x0408102040004020ULL,
+    0x1008040200020408ULL, 0x2010080500050810ULL, 0x4020110A000A1120ULL,
+    0x8041221400142241ULL, 0x0182442800284482ULL, 0x0204885000508804ULL,
+    0x040810A000A01008ULL, 0x0810204000402010ULL, 0x0804020002040810ULL,
+    0x1008050005081020ULL, 0x20110A000A112040ULL, 0x4122140014224180ULL,
+    0x8244280028448201ULL, 0x0488500050880402ULL, 0x0810A000A0100804ULL,
+    0x1020400040201008ULL, 0x0402000204081020ULL, 0x0805000508102040ULL,
+    0x110A000A11204080ULL, 0x2214001422418000ULL, 0x4428002844820100ULL,
+    0x8850005088040201ULL, 0x10A000A010080402ULL, 0x2040004020100804ULL,
+    0x0200020408102040ULL, 0x0500050810204080ULL, 0x0A000A1120408000ULL,
+    0x1400142241800000ULL, 0x2800284482010000ULL, 0x5000508804020100ULL,
+    0xA000A01008040201ULL, 0x4000402010080402ULL, 0x0002040810204080ULL,
+    0x0005081020408000ULL, 0x000A112040800000ULL, 0x0014224180000000ULL,
+    0x0028448201000000ULL, 0x0050880402010000ULL, 0x00A0100804020100ULL,
+    0x0040201008040201ULL};
+// Which squares can knight attack.
+static const BitBoard kKnightAttacks[] = {
+    0x0000000000020400ULL, 0x0000000000050800ULL, 0x00000000000A1100ULL,
+    0x0000000000142200ULL, 0x0000000000284400ULL, 0x0000000000508800ULL,
+    0x0000000000A01000ULL, 0x0000000000402000ULL, 0x0000000002040004ULL,
+    0x0000000005080008ULL, 0x000000000A110011ULL, 0x0000000014220022ULL,
+    0x0000000028440044ULL, 0x0000000050880088ULL, 0x00000000A0100010ULL,
+    0x0000000040200020ULL, 0x0000000204000402ULL, 0x0000000508000805ULL,
+    0x0000000A1100110AULL, 0x0000001422002214ULL, 0x0000002844004428ULL,
+    0x0000005088008850ULL, 0x000000A0100010A0ULL, 0x0000004020002040ULL,
+    0x0000020400040200ULL, 0x0000050800080500ULL, 0x00000A1100110A00ULL,
+    0x0000142200221400ULL, 0x0000284400442800ULL, 0x0000508800885000ULL,
+    0x0000A0100010A000ULL, 0x0000402000204000ULL, 0x0002040004020000ULL,
+    0x0005080008050000ULL, 0x000A1100110A0000ULL, 0x0014220022140000ULL,
+    0x0028440044280000ULL, 0x0050880088500000ULL, 0x00A0100010A00000ULL,
+    0x0040200020400000ULL, 0x0204000402000000ULL, 0x0508000805000000ULL,
+    0x0A1100110A000000ULL, 0x1422002214000000ULL, 0x2844004428000000ULL,
+    0x5088008850000000ULL, 0xA0100010A0000000ULL, 0x4020002040000000ULL,
+    0x0400040200000000ULL, 0x0800080500000000ULL, 0x1100110A00000000ULL,
+    0x2200221400000000ULL, 0x4400442800000000ULL, 0x8800885000000000ULL,
+    0x100010A000000000ULL, 0x2000204000000000ULL, 0x0004020000000000ULL,
+    0x0008050000000000ULL, 0x00110A0000000000ULL, 0x0022140000000000ULL,
+    0x0044280000000000ULL, 0x0088500000000000ULL, 0x0010A00000000000ULL,
+    0x0020400000000000ULL};
+// Opponent pawn attacks
+static const BitBoard kPawnAttacks[] = {
+    0x0000000000000200ULL, 0x0000000000000500ULL, 0x0000000000000A00ULL,
+    0x0000000000001400ULL, 0x0000000000002800ULL, 0x0000000000005000ULL,
+    0x000000000000A000ULL, 0x0000000000004000ULL, 0x0000000000020000ULL,
+    0x0000000000050000ULL, 0x00000000000A0000ULL, 0x0000000000140000ULL,
+    0x0000000000280000ULL, 0x0000000000500000ULL, 0x0000000000A00000ULL,
+    0x0000000000400000ULL, 0x0000000002000000ULL, 0x0000000005000000ULL,
+    0x000000000A000000ULL, 0x0000000014000000ULL, 0x0000000028000000ULL,
+    0x0000000050000000ULL, 0x00000000A0000000ULL, 0x0000000040000000ULL,
+    0x0000000200000000ULL, 0x0000000500000000ULL, 0x0000000A00000000ULL,
+    0x0000001400000000ULL, 0x0000002800000000ULL, 0x0000005000000000ULL,
+    0x000000A000000000ULL, 0x0000004000000000ULL, 0x0000020000000000ULL,
+    0x0000050000000000ULL, 0x00000A0000000000ULL, 0x0000140000000000ULL,
+    0x0000280000000000ULL, 0x0000500000000000ULL, 0x0000A00000000000ULL,
+    0x0000400000000000ULL, 0x0002000000000000ULL, 0x0005000000000000ULL,
+    0x000A000000000000ULL, 0x0014000000000000ULL, 0x0028000000000000ULL,
+    0x0050000000000000ULL, 0x00A0000000000000ULL, 0x0040000000000000ULL,
+    0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+    0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+    0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+    0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+    0x0000000000000000ULL, 0x0000000000000000ULL, 0x0000000000000000ULL,
+    0x0000000000000000ULL};
+
+static const Move::Promotion kPromotions[] = {
+    Move::Promotion::Queen,
+    Move::Promotion::Rook,
+    Move::Promotion::Bishop,
+    Move::Promotion::Knight,
+};
+
+}  // namespace
+
+MoveList ChessBoard::GeneratePseudovalidMoves() const {
+  MoveList result;
+  for (auto source : our_pieces_) {
+    // King
+    if (source == our_king_) {
+      for (const auto& delta : kKingMoves) {
+        const auto dst_row = source.row() + delta.first;
+        const auto dst_col = source.col() + delta.second;
+        if (!BoardSquare::IsValid(dst_row, dst_col)) continue;
+        const BoardSquare destination(dst_row, dst_col);
+        if (our_pieces_.get(destination)) continue;
+        if (IsUnderAttack(destination)) continue;
+        result.emplace_back(source, destination);
+      }
+      // Castlings.
+      if (castlings_.we_can_00()) {
+        bool can_castle = true;
+        for (int i = 5; i < 7; ++i) {
+          if (our_pieces_.get(i) || their_pieces_.get(i)) {
+            can_castle = false;
+            break;
+          }
+        }
+        if (can_castle) {
+          for (auto x : k00Attackers) {
+            if (IsUnderAttack(x)) {
+              can_castle = false;
+              break;
+            }
+          }
+        }
+        if (can_castle) {
+          result.emplace_back(source, BoardSquare(0, 6));
+        }
+      }
+      if (castlings_.we_can_000()) {
+        bool can_castle = true;
+        for (int i = 1; i < 4; ++i) {
+          if (our_pieces_.get(i) || their_pieces_.get(i)) {
+            can_castle = false;
+            break;
+          }
+        }
+        if (can_castle) {
+          for (auto x : k000Attackers) {
+            if (IsUnderAttack(x)) {
+              can_castle = false;
+              break;
+            }
+          }
+        }
+        if (can_castle) {
+          result.emplace_back(source, BoardSquare(0, 2));
+        }
+      }
+      continue;
+    }
+    bool processed_piece = false;
+    // Rook (and queen)
+    if (rooks_.get(source)) {
+      processed_piece = true;
+      for (const auto& direction : kRookDirections) {
+        auto dst_row = source.row();
+        auto dst_col = source.col();
+        while (true) {
+          dst_row += direction.first;
+          dst_col += direction.second;
+          if (!BoardSquare::IsValid(dst_row, dst_col)) break;
+          const BoardSquare destination(dst_row, dst_col);
+          if (our_pieces_.get(destination)) break;
+          result.emplace_back(source, destination);
+          if (their_pieces_.get(destination)) break;
+        }
+      }
+    }
+    // Bishop (and queen)
+    if (bishops_.get(source)) {
+      processed_piece = true;
+      for (const auto& direction : kBishopDirections) {
+        auto dst_row = source.row();
+        auto dst_col = source.col();
+        while (true) {
+          dst_row += direction.first;
+          dst_col += direction.second;
+          if (!BoardSquare::IsValid(dst_row, dst_col)) break;
+          const BoardSquare destination(dst_row, dst_col);
+          if (our_pieces_.get(destination)) break;
+          result.emplace_back(source, destination);
+          if (their_pieces_.get(destination)) break;
+        }
+      }
+    }
+    if (processed_piece) continue;
+    // Pawns.
+    if ((pawns_ * kPawnMask).get(source)) {
+      // Moves forward.
+      {
+        const auto dst_row = source.row() + 1;
+        const auto dst_col = source.col();
+        const BoardSquare destination(dst_row, dst_col);
+
+        if (!our_pieces_.get(destination) && !their_pieces_.get(destination)) {
+          if (dst_row != 7) {
+            result.emplace_back(source, destination);
+            if (dst_row == 2) {
+              // Maybe it'll be possible to move two squares.
+              if (!our_pieces_.get(3, dst_col) &&
+                  !their_pieces_.get(3, dst_col)) {
+                result.emplace_back(source, BoardSquare(3, dst_col));
+              }
+            }
+          } else {
+            // Promotions
+            for (auto promotion : kPromotions) {
+              result.emplace_back(source, destination, promotion);
+            }
+          }
+        }
+      }
+      // Captures.
+      {
+        for (auto direction : {-1, 1}) {
+          const auto dst_row = source.row() + 1;
+          const auto dst_col = source.col() + direction;
+          if (dst_col < 0 || dst_col >= 8) continue;
+          const BoardSquare destination(dst_row, dst_col);
+          if (their_pieces_.get(destination)) {
+            if (dst_row == 7) {
+              // Promotion.
+              for (auto promotion : kPromotions) {
+                result.emplace_back(source, destination, promotion);
+              }
+            } else {
+              // Ordinary capture.
+              result.emplace_back(source, destination);
+            }
+          } else if (dst_row == 5 and pawns_.get(7, dst_col)) {
+            // En passant.
+            result.emplace_back(source, destination);
+          }
+        }
+      }
+      continue;
+    }
+    // Knight.
+    {
+      for (const auto destination : kKnightAttacks[source.as_int()]) {
+        if (our_pieces_.get(destination)) continue;
+        result.emplace_back(source, destination);
+      }
+    }
+  }
+  return result;
+}
+
+bool ChessBoard::ApplyMove(Move move) {
+  const auto& from = move.from();
+  const auto& to = move.to();
+  const auto from_row = from.row();
+  const auto from_col = from.col();
+  const auto to_row = to.row();
+  const auto to_col = to.col();
+
+  // Move in our pieces.
+  our_pieces_.reset(from);
+  our_pieces_.set(to);
+
+  // Remove captured piece
+  bool reset_50_moves = their_pieces_.get(to);
+  their_pieces_.reset(to);
+  rooks_.reset(to);
+  bishops_.reset(to);
+  pawns_.reset(to);
+  if (to.as_int() == 63) {
+    castlings_.reset_they_can_00();
+  }
+  if (to.as_int() == 56) {
+    castlings_.reset_they_can_000();
+  }
+
+  // En passant
+  if (from_row == 4 && pawns_.get(from) && from_col != to_col &&
+      pawns_.get(7, to_col)) {
+    pawns_.reset(4, to_col);
+    their_pieces_.reset(4, to_col);
+  }
+
+  // Remove en passant flags.
+  pawns_ *= kPawnMask;
+
+  // If pawn was moved, reset 50 move draw counter.
+  reset_50_moves |= pawns_.get(from);
+
+  // King
+  if (from == our_king_) {
+    castlings_.reset_we_can_00();
+    castlings_.reset_we_can_000();
+    our_king_ = to;
+    // Castling
+    if (to_col - from_col == 2) {
+      // 0-0
+      our_pieces_.reset(7);
+      rooks_.reset(7);
+      our_pieces_.set(5);
+      rooks_.set(5);
+    } else if (from_col - to_col == 2) {
+      // 0-0-0
+      our_pieces_.reset(0);
+      rooks_.reset(0);
+      our_pieces_.set(3);
+      rooks_.set(3);
+    }
+    return reset_50_moves;
+  }
+
+  // Promotion
+  if (move.promotion() != Move::Promotion::None) {
+    switch (move.promotion()) {
+      case Move::Promotion::Rook:
+        rooks_.set(to);
+        break;
+      case Move::Promotion::Bishop:
+        bishops_.set(to);
+        break;
+      case Move::Promotion::Queen:
+        rooks_.set(to);
+        bishops_.set(to);
+        break;
+      default:;
+    }
+    pawns_.reset(from);
+    return true;
+  }
+
+  // Reset castling rights.
+  if (from.as_int() == 0) {
+    castlings_.reset_we_can_000();
+  }
+  if (from.as_int() == 7) {
+    castlings_.reset_we_can_00();
+  }
+
+  // Ordinary move.
+  rooks_.set_if(to, rooks_.get(from));
+  bishops_.set_if(to, bishops_.get(from));
+  pawns_.set_if(to, pawns_.get(from));
+  rooks_.reset(from);
+  bishops_.reset(from);
+  pawns_.reset(from);
+
+  // Set en passant flag.
+  if (to_row - from_row == 2 and pawns_.get(to)) {
+    pawns_.set(0, to_col);
+  }
+  return reset_50_moves;
+}
+
+bool ChessBoard::IsUnderAttack(BoardSquare square) const {
+  const int row = square.row();
+  const int col = square.col();
+  // Check king
+  {
+    const int krow = their_king_.row();
+    const int kcol = their_king_.col();
+    if (std::abs(krow - row) <= 1 && std::abs(kcol - col) <= 1) return true;
+  }
+  // Check Rooks (and queen)
+  if (kRookAttacks[square.as_int()].intersects(their_pieces_ * rooks_)) {
+    for (const auto& direction : kRookDirections) {
+      auto dst_row = row;
+      auto dst_col = col;
+      while (true) {
+        dst_row += direction.first;
+        dst_col += direction.second;
+        if (!BoardSquare::IsValid(dst_row, dst_col)) break;
+        const BoardSquare destination(dst_row, dst_col);
+        if (our_pieces_.get(destination)) break;
+        if (their_pieces_.get(destination)) {
+          if (rooks_.get(destination)) return true;
+          break;
+        }
+      }
+    }
+  }
+  // Check Bishops
+  if (kBishopAttacks[square.as_int()].intersects(their_pieces_ * bishops_)) {
+    for (const auto& direction : kBishopDirections) {
+      auto dst_row = row;
+      auto dst_col = col;
+      while (true) {
+        dst_row += direction.first;
+        dst_col += direction.second;
+        if (!BoardSquare::IsValid(dst_row, dst_col)) break;
+        const BoardSquare destination(dst_row, dst_col);
+        if (our_pieces_.get(destination)) break;
+        if (their_pieces_.get(destination)) {
+          if (bishops_.get(destination)) return true;
+          break;
+        }
+      }
+    }
+  }
+  // Check pawns
+  if (kPawnAttacks[square.as_int()].intersects(their_pieces_ * pawns_)) {
+    return true;
+  }
+  // Check knights
+  {
+    if (kKnightAttacks[square.as_int()].intersects(their_pieces_ - their_king_ -
+                                                   rooks_ - bishops_ -
+                                                   (pawns_ * kPawnMask))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::vector<MoveExecution> ChessBoard::GenerateValidMoves() const {
+  MoveList move_list = GeneratePseudovalidMoves();
+  std::vector<MoveExecution> result;
+
+  for (const auto& move : move_list) {
+    result.emplace_back();
+    auto& newboard = result.back().board;
+    newboard = *this;
+    result.back().reset_50_moves = newboard.ApplyMove(move);
+    if (newboard.IsUnderCheck()) {
+      result.pop_back();
+      continue;
+    }
+    result.back().move = move;
+  }
+  return result;
+}
+
+void ChessBoard::SetFromFen(const std::string& fen, int* no_capture_ply,
+                            int* moves) {
+  Clear();
+  int row = 7;
+  int col = 0;
+
+  std::istringstream fen_str(fen);
+  string board;
+  string who_to_move;
+  string castlings;
+  string en_passant;
+  int no_capture_halfmoves;
+  int total_moves;
+  fen_str >> board >> who_to_move >> castlings >> en_passant >>
+      no_capture_halfmoves >> total_moves;
+
+  if (!fen_str) throw Exception("Bad fen string: " + fen);
+
+  for (char c : board) {
+    if (c == '/') {
+      --row;
+      col = 0;
+      continue;
+    }
+    if (std::isdigit(c)) {
+      col += c - '0';
+      continue;
+    }
+
+    if (std::isupper(c)) {
+      // White piece.
+      our_pieces_.set(row, col);
+    } else {
+      // Black piece.
+      their_pieces_.set(row, col);
+    }
+
+    if (c == 'K') {
+      our_king_.set(row, col);
+    } else if (c == 'k') {
+      their_king_.set(row, col);
+    } else if (c == 'R' || c == 'r') {
+      rooks_.set(row, col);
+    } else if (c == 'B' || c == 'b') {
+      bishops_.set(row, col);
+    } else if (c == 'Q' || c == 'q') {
+      rooks_.set(row, col);
+      bishops_.set(row, col);
+    } else if (c == 'P' || c == 'p') {
+      pawns_.set(row, col);
+    } else if (c == 'N' || c == 'n') {
+      // Do nothing
+    } else {
+      throw Exception("Bad fen string: " + fen);
+    }
+    ++col;
+  }
+
+  if (castlings != "-") {
+    for (char c : castlings) {
+      switch (c) {
+        case 'K':
+          castlings_.set_we_can_00();
+          break;
+        case 'k':
+          castlings_.set_they_can_00();
+          break;
+        case 'Q':
+          castlings_.set_we_can_000();
+          break;
+        case 'q':
+          castlings_.set_they_can_000();
+          break;
+        default:
+          throw Exception("Bad fen string: " + fen);
+      }
+    }
+  }
+
+  if (en_passant != "-") {
+    auto square = BoardSquare(en_passant);
+    if (square.row() != 2 && square.row() != 5)
+      throw Exception("Bad fen string: " + fen + " wrong en passant rank");
+    pawns_.set((square.row() == 2) ? 0 : 7, square.col());
+  }
+
+  if (who_to_move == "b") {
+    Mirror();
+  }
+  if (no_capture_ply) *no_capture_ply = no_capture_halfmoves;
+  if (moves) *moves = total_moves;
+}
+
+bool ChessBoard::HasMatingMaterial() const {
+  if (!rooks_.empty() || !pawns_.empty()) {
+    return true;
+  }
+
+  int our = __builtin_popcountll(our_pieces_.as_int());
+  int their = __builtin_popcountll(their_pieces_.as_int());
+  if (our > 2 || their > 2) {
+    return true;
+  }
+
+  if (our == 1 || their == 1) return false;
+
+  bool odd_bishop = false;
+  bool even_bishop = false;
+  int bishop_count = 0;
+  for (auto x : bishops_) {
+    ++bishop_count;
+    if (x.as_int() % 2)
+      odd_bishop = true;
+    else
+      even_bishop = true;
+  }
+  if (bishop_count > 1 && (even_bishop != odd_bishop)) return false;
+  return true;
+}
+
+string ChessBoard::DebugString() const {
+  string result;
+  for (int i = 7; i >= 0; --i) {
+    for (int j = 0; j < 8; ++j) {
+      if (!our_pieces_.get(i, j) && !their_pieces_.get(i, j)) {
+        if (i == 2 && pawns_.get(0, j))
+          result += '*';
+        else if (i == 5 && pawns_.get(7, j))
+          result += '*';
+        else
+          result += '.';
+        continue;
+      }
+      if (our_king_ == i * 8 + j) {
+        result += 'K';
+        continue;
+      }
+      if (their_king_ == i * 8 + j) {
+        result += 'k';
+        continue;
+      }
+      char c = '?';
+      if ((pawns_ * kPawnMask).get(i, j)) {
+        c = 'p';
+      } else if (bishops_.get(i, j)) {
+        if (rooks_.get(i, j))
+          c = 'q';
+        else
+          c = 'b';
+      } else if (rooks_.get(i, j)) {
+        c = 'r';
+      } else {
+        c = 'n';
+      }
+      if (our_pieces_.get(i, j)) c = std::toupper(c);
+      result += c;
+    }
+    if (i == 0) {
+      result += " " + castlings_.as_string();
+      result += flipped_ ? " (from black's eyes)" : "(from white's eyes)";
+    }
+    result += '\n';
+  }
+  return result;
+}
+
+}  // namespace lczero

--- a/lc0/src/chess/board.h
+++ b/lc0/src/chess/board.h
@@ -1,0 +1,159 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <string>
+#include "chess/bitboard.h"
+
+namespace lczero {
+
+struct MoveExecution;
+
+// Represents a board position.
+// Unlike most chess engines, the board is mirrored for black.
+class ChessBoard {
+ public:
+  static const std::string kStartingFen;
+
+  // Sets position from FEN string.
+  // If @no_capture_ply and @moves are not nullptr, they are filled with number
+  // of moves without capture and number of full moves since the beginning of
+  // the game.
+  void SetFromFen(const std::string& fen, int* no_capture_ply = nullptr,
+                  int* moves = nullptr);
+  // Nullifies the whole structure.
+  void Clear();
+  // Swaps black and white pieces and mirrors them relative to the
+  // middle of the board. (what was on file 1 appears on file 8, what was
+  // on rank b remains on b).
+  void Mirror();
+
+  // Generates list of possible moves for "ours" (white), but may leave king
+  // under check.
+  MoveList GeneratePseudovalidMoves() const;
+  // Applies the move. (Only for "ours" (white)). Returns true if 50 moves
+  // counter should be removed.
+  bool ApplyMove(Move move);
+  // Checks if the square is under attack from "theirs" (black).
+  bool IsUnderAttack(BoardSquare square) const;
+  // Checks if "our" (white) king is under check.
+  bool IsUnderCheck() const { return IsUnderAttack(our_king_); }
+  // Checks whether at least one of the sides has mating material.
+  bool HasMatingMaterial() const;
+  // Returns a list of valid moves and board positions after the move is made.
+  std::vector<MoveExecution> GenerateValidMoves() const;
+
+  class Castlings {
+   public:
+    void set_we_can_00() { data_ |= 1; }
+    void set_we_can_000() { data_ |= 2; }
+    void set_they_can_00() { data_ |= 4; }
+    void set_they_can_000() { data_ |= 8; }
+
+    void reset_we_can_00() { data_ &= ~1; }
+    void reset_we_can_000() { data_ &= ~2; }
+    void reset_they_can_00() { data_ &= ~4; }
+    void reset_they_can_000() { data_ &= ~8; }
+
+    bool we_can_00() const { return data_ & 1; }
+    bool we_can_000() const { return data_ & 2; }
+    bool they_can_00() const { return data_ & 4; }
+    bool they_can_000() const { return data_ & 8; }
+
+    void Mirror() { data_ = ((data_ & 0b11) << 2) + ((data_ & 0b1100) >> 2); }
+
+    std::string as_string() const {
+      if (data_ == 0) return "-";
+      std::string result;
+      if (we_can_00()) result += 'K';
+      if (we_can_000()) result += 'Q';
+      if (they_can_00()) result += 'k';
+      if (they_can_000()) result += 'q';
+      return result;
+    }
+
+    bool operator==(const Castlings& other) const {
+      return data_ == other.data_;
+    }
+
+   private:
+    std::uint8_t data_ = 0;
+  };
+
+  std::string DebugString() const;
+
+  BitBoard ours() const { return our_pieces_; }
+  BitBoard theirs() const { return their_pieces_; }
+  BitBoard pawns() const { return pawns_ * kPawnMask; }
+  BitBoard bishops() const { return bishops_ - rooks_; }
+  BitBoard rooks() const { return rooks_ - bishops_; }
+  BitBoard queens() const { return rooks_ * bishops_; }
+  BitBoard our_knights() const {
+    return our_pieces_ - pawns() - our_king_ - rooks_ - bishops_;
+  }
+  BitBoard their_knights() const {
+    return their_pieces_ - pawns() - their_king_ - rooks_ - bishops_;
+  }
+  BitBoard our_king() const { return 1ull << our_king_.as_int(); }
+  BitBoard their_king() const { return 1ull << their_king_.as_int(); }
+  const Castlings& castlings() const { return castlings_; }
+  bool flipped() const { return flipped_; }
+
+  bool operator==(const ChessBoard& other) const {
+    return (our_pieces_ == other.our_pieces_) &&
+           (their_pieces_ == other.their_pieces_) && (rooks_ == other.rooks_) &&
+           (bishops_ == other.bishops_) && (pawns_ == other.pawns_) &&
+           (our_king_ == other.our_king_) &&
+           (their_king_ == other.their_king_) &&
+           (castlings_ == other.castlings_) && (flipped_ == other.flipped_);
+  }
+
+  bool operator!=(const ChessBoard& other) const { return !operator==(other); }
+
+ private:
+  static constexpr BitBoard kPawnMask = 0x00FFFFFFFFFFFF00ULL;
+
+  // All white pieces.
+  BitBoard our_pieces_;
+  // All black pieces.
+  BitBoard their_pieces_;
+  // Rooks and queens.
+  BitBoard rooks_;
+  // Bishops and queens;
+  BitBoard bishops_;
+  // Pawns.
+  // Ranks 1 and 8 have special meaning. Pawn at rank 1 means that
+  // corresponding white pawn on rank 4 can be taken en passant. Rank 8 is the
+  // same for black pawns. Those "fake" pawns are not present in white_ and
+  // black_ bitboards.
+  BitBoard pawns_;
+  BoardSquare our_king_;
+  BoardSquare their_king_;
+  Castlings castlings_;
+  bool flipped_ = false;  // aka "Black to move".
+};
+
+// Stores the move and state of the board after the move is done.
+struct MoveExecution {
+  Move move;
+  ChessBoard board;
+  bool reset_50_moves;
+};
+
+}  // namespace lczero

--- a/lc0/src/chess/board_test.cc
+++ b/lc0/src/chess/board_test.cc
@@ -1,0 +1,164 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include "src/chess/bitboard.h"
+#include "src/chess/board.h"
+
+namespace lczero {
+
+TEST(BoardSquare, BoardSquare) {
+  {
+    auto x = BoardSquare(10);  // Should be c2
+    EXPECT_EQ(x.row(), 1);
+    EXPECT_EQ(x.col(), 2);
+  }
+
+  {
+    auto x = BoardSquare("c2");
+    EXPECT_EQ(x.row(), 1);
+    EXPECT_EQ(x.col(), 2);
+  }
+
+  {
+    auto x = BoardSquare(1, 2);
+    EXPECT_EQ(x.row(), 1);
+    EXPECT_EQ(x.col(), 2);
+  }
+
+  {
+    auto x = BoardSquare(1, 2);
+    x.Mirror();
+    EXPECT_EQ(x.row(), 6);
+    EXPECT_EQ(x.col(), 2);
+  }
+}
+
+TEST(ChessBoard, PseudovalidMovesStartingPos) {
+  ChessBoard board;
+  board.SetFromFen(ChessBoard::kStartingFen);
+  board.Mirror();
+  auto moves = board.GeneratePseudovalidMoves();
+
+  EXPECT_EQ(moves.size(), 20);
+}
+
+namespace {
+int Perft(const ChessBoard& board, int max_depth, bool dump = false,
+          int depth = 0) {
+  if (depth == max_depth) return 1;
+  int total_count = 0;
+  auto moves = board.GeneratePseudovalidMoves();
+  for (const auto& move : moves) {
+    auto new_board = board;
+    new_board.ApplyMove(move);
+    if (new_board.IsUnderCheck()) continue;
+    new_board.Mirror();
+    int count = Perft(new_board, max_depth, dump, depth + 1);
+    if (dump && depth == 0) {
+      Move m = move;
+      if (depth == 0) m.Mirror();
+      std::cerr << m.as_string() << ' ' << count << '\n'
+                << new_board.DebugString();
+    }
+    total_count += count;
+  }
+  return total_count;
+}
+}  // namespace
+
+TEST(ChessBoard, MoveGenStartingPos) {
+  ChessBoard board;
+  board.SetFromFen(ChessBoard::kStartingFen);
+
+  EXPECT_EQ(Perft(board, 0), 1);
+  EXPECT_EQ(Perft(board, 1), 20);
+  EXPECT_EQ(Perft(board, 2), 400);
+  EXPECT_EQ(Perft(board, 3), 8902);
+  EXPECT_EQ(Perft(board, 4), 197281);
+  EXPECT_EQ(Perft(board, 5), 4865609);
+  EXPECT_EQ(Perft(board, 6), 119060324);
+}
+
+TEST(ChessBoard, MoveGenKiwipete) {
+  ChessBoard board;
+  board.SetFromFen(
+      "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq -");
+
+  EXPECT_EQ(Perft(board, 1), 48);
+  EXPECT_EQ(Perft(board, 2), 2039);
+  EXPECT_EQ(Perft(board, 3), 97862);
+  EXPECT_EQ(Perft(board, 4), 4085603);
+  EXPECT_EQ(Perft(board, 5), 193690690);
+}
+
+TEST(ChessBoard, MoveGenPosition3) {
+  ChessBoard board;
+  board.SetFromFen("8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8 w - -");
+
+  EXPECT_EQ(Perft(board, 1), 14);
+  EXPECT_EQ(Perft(board, 2), 191);
+  EXPECT_EQ(Perft(board, 3), 2812);
+  EXPECT_EQ(Perft(board, 4), 43238);
+  EXPECT_EQ(Perft(board, 5), 674624);
+  EXPECT_EQ(Perft(board, 6), 11030083);
+}
+
+TEST(ChessBoard, MoveGenPosition4) {
+  ChessBoard board;
+  board.SetFromFen(
+      "r2q1rk1/pP1p2pp/Q4n2/bbp1p3/Np6/1B3NBn/pPPP1PPP/R3K2R b KQ - 0 1");
+
+  EXPECT_EQ(Perft(board, 1), 6);
+  EXPECT_EQ(Perft(board, 2), 264);
+  EXPECT_EQ(Perft(board, 3), 9467);
+  EXPECT_EQ(Perft(board, 4), 422333);
+  EXPECT_EQ(Perft(board, 5), 15833292);
+}
+
+TEST(ChessBoard, MoveGenPosition5) {
+  ChessBoard board;
+  board.SetFromFen("rnbq1k1r/pp1Pbppp/2p5/8/2B5/8/PPP1NnPP/RNBQK2R w KQ - 1 8");
+
+  EXPECT_EQ(Perft(board, 1), 44);
+  EXPECT_EQ(Perft(board, 2), 1486);
+  EXPECT_EQ(Perft(board, 3), 62379);
+  EXPECT_EQ(Perft(board, 4), 2103487);
+  EXPECT_EQ(Perft(board, 5), 89941194);
+}
+
+TEST(ChessBoard, MoveGenPosition6) {
+  ChessBoard board;
+  board.SetFromFen(
+      "r4rk1/1pp1qppp/p1np1n2/2b1p1B1/2B1P1b1/P1NP1N2/1PP1QPPP/R4RK1 w - - 0 "
+      "10");
+
+  EXPECT_EQ(Perft(board, 1), 46);
+  EXPECT_EQ(Perft(board, 2), 2079);
+  EXPECT_EQ(Perft(board, 3), 89890);
+  EXPECT_EQ(Perft(board, 4), 3894594);
+}
+
+}  // namespace lczero
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/lc0/src/engine.cc
+++ b/lc0/src/engine.cc
@@ -1,0 +1,155 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <functional>
+
+#include "engine.h"
+#include "mcts/search.h"
+#include "neural/loader.h"
+#include "neural/network_tf.h"
+
+namespace lczero {
+namespace {
+const int kDefaultThreads = 2;
+const char* kThreadsOption = "Number of worker threads";
+
+const char* kAutoDiscover = "<autodiscover>";
+}  // namespace
+
+EngineController::EngineController(BestMoveInfo::Callback best_move_callback,
+                                   UciInfo::Callback info_callback)
+    : best_move_callback_(best_move_callback), info_callback_(info_callback) {}
+
+void EngineController::GetUciOptions(UciOptions* options) {
+  uci_options_ = options;
+  using namespace std::placeholders;
+  options->Add(std::make_unique<StringOption>(
+      "Network weights file path", kAutoDiscover,
+      std::bind(&EngineController::SetNetworkPath, this, _1), "weights", 'w'));
+
+  options->Add(std::make_unique<SpinOption>(kThreadsOption, kDefaultThreads, 1,
+                                            128, std::function<void(int)>{},
+                                            "threads", 't'));
+  Search::PopulateUciParams(options);
+}
+
+void EngineController::SetNetworkPath(const std::string& path) {
+  SharedLock lock(busy_mutex_);
+  std::string net_path;
+  if (path == kAutoDiscover) {
+    net_path = DiscoveryWeightsFile(
+        uci_options_ ? uci_options_->GetProgramName() : ".");
+  }
+  Weights weights = LoadWeightsFromFile(net_path);
+  // TODO Make backend selection.
+  network_ = MakeTensorflowNetwork(weights);
+}
+
+void EngineController::NewGame() {
+  SharedLock lock(busy_mutex_);
+  search_.reset();
+  node_pool_.reset();
+  current_head_ = nullptr;
+  gamebegin_node_ = nullptr;
+}
+
+void EngineController::MakeMove(Move move) {
+  if (current_head_->board.flipped()) move.Mirror();
+
+  Node* new_head = nullptr;
+  for (Node* n = current_head_->child; n; n = n->sibling) {
+    if (n->move == move) {
+      new_head = n;
+      break;
+    }
+  }
+  node_pool_->ReleaseAllChildrenExceptOne(current_head_, new_head);
+  if (!new_head) {
+    new_head = node_pool_->GetNode();
+    current_head_->child = new_head;
+    new_head->parent = current_head_;
+    new_head->board_flipped = current_head_->board;
+    const bool capture = new_head->board_flipped.ApplyMove(move);
+    new_head->board = new_head->board_flipped;
+    new_head->board.Mirror();
+    new_head->ply_count = current_head_->ply_count + 1;
+    new_head->no_capture_ply = capture ? 0 : current_head_->no_capture_ply + 1;
+    new_head->repetitions = ComputeRepetitions(new_head);
+  }
+  current_head_ = new_head;
+}
+
+void EngineController::SetPosition(const std::string& fen,
+                                   const std::vector<std::string>& moves) {
+  SharedLock lock(busy_mutex_);
+  search_.reset();
+  ChessBoard starting_board;
+  int no_capture_ply;
+  int full_moves;
+  starting_board.SetFromFen(fen, &no_capture_ply, &full_moves);
+
+  if (gamebegin_node_ && gamebegin_node_->board != starting_board) {
+    // Completely different position.
+    node_pool_.reset();
+    current_head_ = nullptr;
+    gamebegin_node_ = nullptr;
+  }
+
+  if (!node_pool_) node_pool_ = std::make_unique<NodePool>();
+
+  if (!gamebegin_node_) {
+    gamebegin_node_ = node_pool_->GetNode();
+    gamebegin_node_->board = starting_board;
+    gamebegin_node_->board_flipped = starting_board;
+    gamebegin_node_->board_flipped.Mirror();
+    gamebegin_node_->no_capture_ply = no_capture_ply;
+    gamebegin_node_->ply_count =
+        full_moves * 2 - (starting_board.flipped() ? 1 : 2);
+  }
+
+  current_head_ = gamebegin_node_;
+  for (const auto& move : moves) {
+    MakeMove(move);
+  }
+  node_pool_->ReleaseChildren(current_head_);
+}
+
+void EngineController::Go(const GoParams& params) {
+  if (!current_head_) {
+    SetPosition(ChessBoard::kStartingFen, {});
+  }
+
+  SearchLimits limits;
+  limits.nodes = params.nodes;
+  limits.time_ms =
+      (current_head_->board.flipped() ? params.btime : params.wtime);
+  if (limits.time_ms >= 0) limits.time_ms /= 20;
+
+  search_ = std::make_unique<Search>(current_head_, node_pool_.get(),
+                                     network_.get(), best_move_callback_,
+                                     info_callback_, limits, uci_options_);
+
+  search_->StartThreads(uci_options_ ? uci_options_->GetIntValue(kThreadsOption)
+                                     : kDefaultThreads);
+}
+
+void EngineController::Stop() {
+  if (search_) search_->Stop();
+}
+
+}  // namespace lczero

--- a/lc0/src/engine.cc
+++ b/lc0/src/engine.cc
@@ -54,6 +54,8 @@ void EngineController::SetNetworkPath(const std::string& path) {
   if (path == kAutoDiscover) {
     net_path = DiscoveryWeightsFile(
         uci_options_ ? uci_options_->GetProgramName() : ".");
+  } else {
+    net_path = path;
   }
   Weights weights = LoadWeightsFromFile(net_path);
   // TODO Make backend selection.

--- a/lc0/src/engine.h
+++ b/lc0/src/engine.h
@@ -1,0 +1,91 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <shared_mutex>
+#include "mcts/search.h"
+#include "neural/network.h"
+#include "uciloop.h"
+#include "ucioptions.h"
+#include "utils/readprefmutex.h"
+
+namespace lczero {
+
+struct GoParams {
+  std::int64_t wtime = -1;
+  std::int64_t btime = -1;
+  std::int64_t winc = -1;
+  std::int64_t binc = -1;
+  int movestogo = -1;
+  int depth = -1;
+  int nodes = -1;
+  std::int64_t movetime = -1;
+  bool infinite = false;
+};
+
+class EngineController {
+ public:
+  EngineController(BestMoveInfo::Callback best_move_callback,
+                   UciInfo::Callback info_callback);
+
+  ~EngineController() {
+    // Make sure search is destructed first, and it still may be running in
+    // a separate thread.
+    search_.reset();
+  }
+
+  void GetUciOptions(UciOptions* options);
+
+  // Blocks.
+  void EnsureReady() { std::unique_lock<rp_shared_mutex> lock(busy_mutex_); }
+
+  // Must not block.
+  void NewGame();
+
+  // Blocks.
+  void SetPosition(const std::string& fen,
+                   const std::vector<std::string>& moves);
+
+  // Must not block.
+  void Go(const GoParams& params);
+  // Must not block.
+  void Stop();
+  void SetNetworkPath(const std::string& path);
+
+ private:
+  void MakeMove(Move move);
+  void CreateNodeRoot();
+
+  UciOptions* uci_options_ = nullptr;
+
+  BestMoveInfo::Callback best_move_callback_;
+  UciInfo::Callback info_callback_;
+
+  std::unique_ptr<Network> network_;
+  // Locked means that there is some work to wait before responding readyok.
+  rp_shared_mutex busy_mutex_;
+  using SharedLock = std::shared_lock<rp_shared_mutex>;
+
+  std::unique_ptr<NodePool> node_pool_;
+  Node* current_head_ = nullptr;
+  Node* gamebegin_node_ = nullptr;
+  std::unique_ptr<Search> search_;
+};
+
+}  // namespace lczero

--- a/lc0/src/main.cc
+++ b/lc0/src/main.cc
@@ -1,0 +1,21 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "uciloop.h"
+
+int main(int argc, const char** argv) { lczero::UciLoop(argc, argv); }

--- a/lc0/src/mcts/node.cc
+++ b/lc0/src/mcts/node.cc
@@ -1,0 +1,114 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "mcts/node.h"
+
+#include <cstring>
+#include <sstream>
+
+namespace lczero {
+
+namespace {
+const int kAllocationSize = 1024 * 64;
+}
+
+Node* NodePool::GetNode() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (pool_.empty()) {
+    AllocateNewBatch();
+  }
+
+  Node* result = pool_.back();
+  pool_.pop_back();
+  std::memset(result, 0, sizeof(Node));
+  return result;
+}
+
+void NodePool::AllocateNewBatch() {
+  allocations_.emplace_back(std::make_unique<Node[]>(kAllocationSize));
+  for (int i = 0; i < kAllocationSize; ++i) {
+    pool_.push_back(allocations_.back().get() + i);
+  }
+}
+
+void NodePool::ReleaseNode(Node* node) { pool_.push_back(node); }
+
+void NodePool::ReleaseChildren(Node* node) {
+  for (Node* iter = node->child; iter; iter = iter->sibling) {
+    ReleaseSubtree(iter);
+  }
+  node->child = nullptr;
+}
+
+void NodePool::ReleaseSubtree(Node* node) {
+  for (Node* iter = node->child; iter; iter = iter->sibling) {
+    ReleaseSubtree(iter);
+    ReleaseNode(iter);
+  }
+}
+
+void NodePool::ReleaseAllChildrenExceptOne(Node* root, Node* subtree) {
+  Node* child = nullptr;
+  for (Node* iter = root->child; iter; iter = iter->sibling) {
+    if (iter == subtree) {
+      child = iter;
+    } else {
+      ReleaseSubtree(iter);
+    }
+  }
+  root->child = child;
+  if (child) {
+    child->sibling = nullptr;
+  }
+}
+
+uint64_t NodePool::GetAllocatedNodeCount() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return kAllocationSize * allocations_.size() - pool_.size();
+}
+
+std::string Node::DebugString() const {
+  std::ostringstream oss;
+  oss << "Move: " << move.as_string() << "\n"
+      << board.DebugString() << "Term:" << is_terminal << " Parent:" << parent
+      << " child:" << child << " sibling:" << sibling << " P:" << p
+      << " Q:" << q << " W:" << w << " N:" << n << " N_:" << n_in_flight
+      << " Rep:" << (int)repetitions;
+  return oss.str();
+}
+
+int ComputeRepetitions(const Node* ref_node) {
+  // TODO(crem) implement some sort of caching.
+  if (ref_node->no_capture_ply < 2) return 0;
+
+  const Node* node = ref_node;
+  while (true) {
+    node = node->parent;
+    if (!node) break;
+    node = node->parent;
+    if (!node) break;
+
+    if (node->board == ref_node->board) {
+      return 1 + node->repetitions;
+    }
+    if (node->no_capture_ply < 2) return 0;
+  }
+  return 0;
+}
+
+}  // namespace lczero

--- a/lc0/src/mcts/node.h
+++ b/lc0/src/mcts/node.h
@@ -1,0 +1,105 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include "chess/board.h"
+
+namespace lczero {
+
+struct Node {
+  // Move corresponding to this node. From the point of view of a player,
+  // i.e. black's e7e5 is stored as e2e4.
+  // Root node contains move a1a1.
+  Move move;
+  // The board from the point of view of the player to move.
+  ChessBoard board;
+  // The board from the point of view of the opponent. Used to fill historical
+  // planes.
+  ChessBoard board_flipped;
+  // How many half-moves without capture or pawn move was there.
+  std::uint8_t no_capture_ply;
+  // How many repetitions this position had before. For new positions it's 0.
+  std::uint8_t repetitions;
+  // number of half-moves since beginning of the game.
+  std::uint16_t ply_count;
+
+  // (aka virtual loss). How many threads currently process this node (started
+  // but not finished). This value is added to n during selection which node
+  // to pick in MCTS, and also when selecting the best move.
+  uint32_t n_in_flight;
+  // How many completed visits this node had.
+  uint32_t n;
+  // Average value (from value head of neural network) of all visited nodes in
+  // subtree. Terminal nodes (which lead to checkmate or draw) may be visited
+  // several times, those are counted several times. q = w / n
+  float q;
+  // Sum of values of all visited nodes in a subtree. Used to compute an
+  // average.
+  float w;
+  // Probabality that this move will be made. From policy head of the neural
+  // network.
+  float p;
+
+  // Maximum depth any subnodes of this node were looked at.
+  uint16_t max_depth;
+  // Complete depth all subnodes of this node were fully searched.
+  uint16_t full_depth;
+  // Does this node end game (with a winning of either sides or draw).
+  bool is_terminal;
+
+  // Pointer to a parent node. nullptr for the root.
+  Node* parent;
+  // Pointer to a first child. nullptr for leave node.
+  Node* child;
+  // Pointer to a next sibling. nullptr if there are no further siblings.
+  Node* sibling;
+
+  std::string DebugString() const;
+};
+
+int ComputeRepetitions(const Node*);
+
+class NodePool {
+ public:
+  // Allocates a new node and initializes it with all zeros.
+  Node* GetNode();
+  // Return node to the pool.
+  void ReleaseNode(Node*);
+  // Releases all children of the node, except specified. Also updates pointers
+  // accordingly.
+  void ReleaseAllChildrenExceptOne(Node* root, Node* subtree);
+  // Releases all children, but doesn't release the node isself.
+  void ReleaseChildren(Node*);
+  // Release all children of the node and the node itself.
+  void ReleaseSubtree(Node*);
+
+  // Returns total number of nodes allocated.
+  uint64_t GetAllocatedNodeCount() const;
+
+ private:
+  void AllocateNewBatch();
+
+  mutable std::mutex mutex_;
+  std::vector<Node*> pool_;
+  std::vector<std::unique_ptr<Node[]>> allocations_;
+};
+
+}  // namespace lczero

--- a/lc0/src/mcts/search.cc
+++ b/lc0/src/mcts/search.cc
@@ -1,0 +1,464 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "mcts/search.h"
+#include "mcts/node.h"
+
+#include <cmath>
+#include "neural/network_tf.h"
+
+namespace lczero {
+
+namespace {
+
+const int kDefaultMiniBatchSize = 32;
+const char* kMiniBatchSizeOption = "Minibatch size for NN inference";
+
+const int kDefaultCpuct = 170;
+const char* kCpuctOption = "Cpuct MCTS option (x100)";
+
+const bool kDefaultPopulateMoves = false;
+const char* kPopulateMovesOption = "(oldbug) Populate movecount plane";
+
+const bool kDefaultFlipHistory = true;
+const char* kFlipHistoryOption = "(oldbug) Flip opponents history";
+
+const bool kDefaultFlipMove = true;
+const char* kFlipMoveOption = "(oldbug) Flip black's moves";
+}  // namespace
+
+void Search::PopulateUciParams(UciOptions* options) {
+  options->Add(std::make_unique<SpinOption>(kMiniBatchSizeOption,
+                                            kDefaultMiniBatchSize, 1, 128,
+                                            std::function<void(int)>{}));
+
+  options->Add(std::make_unique<SpinOption>(kCpuctOption, kDefaultCpuct, 0,
+                                            9999, std::function<void(int)>{}));
+
+  options->Add(std::make_unique<CheckOption>(kPopulateMovesOption,
+                                             kDefaultPopulateMoves,
+                                             std::function<void(bool)>{}));
+
+  options->Add(std::make_unique<CheckOption>(
+      kFlipHistoryOption, kDefaultFlipHistory, std::function<void(bool)>{}));
+
+  options->Add(std::make_unique<CheckOption>(kFlipMoveOption, kDefaultFlipMove,
+                                             std::function<void(bool)>{}));
+}
+
+Search::Search(Node* root_node, NodePool* node_pool, const Network* network,
+               BestMoveInfo::Callback best_move_callback,
+               UciInfo::Callback info_callback, const SearchLimits& limits,
+               UciOptions* uci_options)
+    : root_node_(root_node),
+      node_pool_(node_pool),
+      network_(network),
+      limits_(limits),
+      start_time_(std::chrono::steady_clock::now()),
+      best_move_callback_(best_move_callback),
+      info_callback_(info_callback),
+      kMiniBatchSize(uci_options
+                         ? uci_options->GetIntValue(kMiniBatchSizeOption)
+                         : kDefaultMiniBatchSize),
+      kCpuct((uci_options ? uci_options->GetIntValue(kCpuctOption)
+                          : kDefaultCpuct) /
+             100.0f),
+      kPopulateMoves(uci_options
+                         ? uci_options->GetBoolValue(kPopulateMovesOption)
+                         : kDefaultPopulateMoves),
+      kFlipHistory(uci_options ? uci_options->GetBoolValue(kFlipHistoryOption)
+                               : kDefaultFlipHistory),
+      kFlipMove(uci_options ? uci_options->GetBoolValue(kFlipMoveOption)
+                            : kDefaultFlipMove) {}
+
+void Search::Worker() {
+  std::vector<Node*> nodes_to_process;
+
+  // do {} while  instead of  while{} because at least one iteration is
+  // necessary to get candidates.
+  do {
+    int new_nodes = 0;
+    nodes_to_process.clear();
+    auto computation = network_->NewComputation();
+
+    // Gather nodes to process in the current batch.
+    for (int i = 0; i < kMiniBatchSize; ++i) {
+      Node* node = PickNodeToExtend(root_node_);
+      // If we hit the node that is already processed (by our batch or in
+      // another thread) stop gathering and process smaller batch.
+      if (!node) break;
+
+      nodes_to_process.push_back(node);
+      // If node is already known as terminal (win/lose/draw according to rules
+      // of the game), it means that we already visited this node before.
+      if (node->is_terminal) continue;
+      ++new_nodes;
+
+      ExtendNode(node);
+
+      // If node turned out to be a terminal one, no need to send to NN for
+      // evaluation.
+      if (!node->is_terminal) {
+        auto planes = EncodeNode(node);
+        computation->AddInput(std::move(planes));
+      }
+    }
+
+    // Evaluate nodes through NN.
+    if (computation->GetBatchSize() != 0) {
+      computation->ComputeBlocking();
+
+      int idx_in_computation = 0;
+      for (Node* node : nodes_to_process) {
+        if (node->is_terminal) continue;
+        // Populate Q value.
+        node->q = -computation->GetQVal(idx_in_computation);
+        // Populate P values.
+        float total = 0.0;
+        for (Node* n = node->child; n; n = n->sibling) {
+          Move m = n->move;
+          if (kFlipMove && node->board.flipped()) m.Mirror();
+          float p = computation->GetPVal(idx_in_computation, m.as_nn_index());
+          total += p;
+          n->p = p;
+        }
+        // Scale P values to add up to 1.0.
+        if (total > 0.0f) {
+          for (Node* n = node->child; n; n = n->sibling) {
+            n->p /= total;
+          }
+        }
+        ++idx_in_computation;
+      }
+    }
+
+    {
+      // Update nodes.
+      std::unique_lock<std::shared_mutex> lock{nodes_mutex_};
+      total_nodes_ += new_nodes;
+      for (Node* node : nodes_to_process) {
+        float v = node->q;
+        // Maximum depth the node is explored.
+        uint16_t depth = 0;
+        // If the node is terminal, mark it as fully explored to an infinite
+        // depth.
+        uint16_t cur_full_depth = node->is_terminal ? 999 : 0;
+        bool full_depth_updated = true;
+        for (Node* n = node; n != root_node_->parent; n = n->parent) {
+          ++depth;
+          // Add new value to W.
+          n->w += v;
+          // Increment N.
+          ++n->n;
+          // Decrement virtual loss.
+          --n->n_in_flight;
+          // Recompute Q.
+          n->q = n->w / n->n;
+          // Q will be flipped for opponent.
+          v = -v;
+
+          // Updating stats.
+          // Max depth.
+          if (depth > n->max_depth) {
+            n->max_depth = depth;
+          }
+          // Full depth.
+          if (full_depth_updated && n->full_depth <= cur_full_depth) {
+            for (Node* iter = n->child; iter; iter = iter->sibling) {
+              if (cur_full_depth > iter->full_depth) {
+                cur_full_depth = iter->full_depth;
+              }
+            }
+            if (cur_full_depth >= n->full_depth) {
+              n->full_depth = ++cur_full_depth;
+            } else {
+              full_depth_updated = false;
+            }
+          }
+          // Best move.
+          if (n->parent == root_node_) {
+            if (!best_move_node_ || best_move_node_->n < n->n) {
+              best_move_node_ = n;
+            }
+          }
+        }
+      }
+    }
+    MaybeOutputInfo();
+    MaybeTriggerStop();
+  } while (!stop_);
+}
+
+namespace {
+// Returns a child with most visits.
+Node* GetBestChild(Node* parent) {
+  Node* best_node = nullptr;
+  int best = -1;
+  for (Node* node = parent->child; node; node = node->sibling) {
+    int n = node->n + node->n_in_flight;
+    if (n > best) {
+      best = n;
+      best_node = node;
+    }
+  }
+  return best_node;
+}
+}  // namespace
+
+// A nodes_mutex_ must be locked when this function is called.
+void Search::SendUciInfo() {
+  if (!best_move_node_) return;
+  last_outputted_best_move_node_ = best_move_node_;
+  uci_info_.depth = root_node_->full_depth;
+  uci_info_.seldepth = root_node_->max_depth;
+  uci_info_.time = GetTimeSinceStart();
+  uci_info_.nodes = total_nodes_;
+  uci_info_.nps = uci_info_.nodes * 1000 / uci_info_.time;
+  uci_info_.score = -91 * log(2 / (best_move_node_->q + 1) - 1);
+  uci_info_.pv.clear();
+
+  for (Node* iter = best_move_node_; iter; iter = GetBestChild(iter)) {
+    Move m = iter->move;
+    if (!iter->board.flipped()) m.Mirror();
+    uci_info_.pv.push_back(m);
+  }
+  uci_info_.comment.clear();
+  info_callback_(uci_info_);
+}
+
+// Decides whether anything important changed in stats and new info should be
+// shown to a user.
+void Search::MaybeOutputInfo() {
+  std::unique_lock<std::shared_mutex> lock{nodes_mutex_};
+  if (best_move_node_ && (best_move_node_ != last_outputted_best_move_node_ ||
+                          uci_info_.depth != root_node_->full_depth ||
+                          uci_info_.seldepth != root_node_->max_depth)) {
+    SendUciInfo();
+  }
+}
+
+uint64_t Search::GetTimeSinceStart() const {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+             std::chrono::steady_clock::now() - start_time_)
+      .count();
+}
+
+void Search::MaybeTriggerStop() {
+  std::lock_guard<std::mutex> lock(counters_mutex_);
+  if (limits_.nodes >= 0 && total_nodes_ >= limits_.nodes) {
+    stop_ = true;
+  }
+  if (limits_.time_ms >= 0 && GetTimeSinceStart() >= limits_.time_ms) {
+    stop_ = true;
+  }
+  if (stop_ && !responded_bestmove_) {
+    responded_bestmove_ = true;
+    SendUciInfo();
+    best_move_callback_(GetBestMove());
+  }
+}
+
+void Search::ExtendNode(Node* node) {
+  // Not taking mutex because other threads will see that N=0 and N-in-flight=1
+  // and will not touch this node.
+  auto& board = node->board;
+  auto valid_moves = board.GenerateValidMoves();
+
+  // Check whether it's a draw/lose by rules.
+  if (valid_moves.empty()) {
+    // Checkmate or stalemate.
+    node->is_terminal = true;
+    if (board.IsUnderCheck()) {
+      // Checkmate.
+      node->q = 1.0f;
+    } else {
+      // Stalemate.
+      node->q = 0.0f;
+    }
+    return;
+  }
+
+  if (!board.HasMatingMaterial()) {
+    node->is_terminal = true;
+    node->q = 0.0f;
+    return;
+  }
+
+  if (node->no_capture_ply >= 100) {
+    node->is_terminal = true;
+    node->q = 0.0f;
+    return;
+  }
+
+  node->repetitions = ComputeRepetitions(node);
+  if (node->repetitions >= 2) {
+    node->is_terminal = true;
+    node->q = 0.0f;
+    return;
+  }
+
+  // Add valid moves as children to this node.
+  Node* prev_node = node;
+  for (const auto& move : valid_moves) {
+    Node* new_node = node_pool_->GetNode();
+
+    new_node->parent = node;
+    if (prev_node == node) {
+      node->child = new_node;
+    } else {
+      prev_node->sibling = new_node;
+    }
+
+    new_node->move = move.move;
+    new_node->board_flipped = move.board;
+    new_node->board = move.board;
+    new_node->board.Mirror();
+    new_node->no_capture_ply =
+        move.reset_50_moves ? 0 : (node->no_capture_ply + 1);
+    new_node->ply_count = node->ply_count + 1;
+    prev_node = new_node;
+  }
+}
+
+Node* Search::PickNodeToExtend(Node* node) {
+  while (true) {
+    {
+      std::unique_lock<std::shared_mutex> lock{nodes_mutex_};
+      // Check whether we are in the leave.
+      if (node->n == 0 && node->n_in_flight > 0) {
+        // The node is currently being processed by another thread.
+        // Undo the increments of anschestor nodes, and return null.
+        for (node = node->parent; node != root_node_->parent;
+             node = node->parent) {
+          --node->n_in_flight;
+        }
+        return nullptr;
+      }
+      ++node->n_in_flight;
+      // Found leave, and we are the the first to visit it.
+      if (!node->child) {
+        return node;
+      }
+    }
+
+    // Now we are not in leave, we need to go deeper.
+    std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
+    float factor = kCpuct * std::sqrt(node->n + 1);
+    float best = -100.0f;
+    for (Node* iter = node->child; iter; iter = iter->sibling) {
+      const float u = factor * iter->p / (1 + iter->n + iter->n_in_flight);
+      const float v = u + iter->q;
+      if (v > best) {
+        best = v;
+        node = iter;
+      }
+    }
+  }
+}
+
+InputPlanes Search::EncodeNode(const Node* node) {
+  const int kMoveHistory = 8;
+  const int kAuxPlaneBase = 14 * kMoveHistory;
+
+  InputPlanes result(kAuxPlaneBase + 8);
+
+  const bool we_are_black = node->board.flipped();
+  bool flip = false;
+
+  for (int i = 0; i < kMoveHistory; ++i, flip = !flip) {
+    if (!node) break;
+    ChessBoard board = flip ? node->board_flipped : node->board;
+
+    if (kFlipHistory && i % 2 == 1) board.Mirror();
+
+    const int base = i * 14;
+    if (i == 0) {
+      if (board.castlings().we_can_000()) result[kAuxPlaneBase + 0].SetAll();
+      if (board.castlings().we_can_00()) result[kAuxPlaneBase + 1].SetAll();
+      if (board.castlings().they_can_000()) result[kAuxPlaneBase + 2].SetAll();
+      if (board.castlings().they_can_00()) result[kAuxPlaneBase + 3].SetAll();
+      if (we_are_black) result[kAuxPlaneBase + 4].SetAll();
+      result[kAuxPlaneBase + 5].Fill(node->no_capture_ply);
+      if (kPopulateMoves) result[kAuxPlaneBase + 6].Fill(node->ply_count % 256);
+    }
+
+    result[base + 0].mask = (board.ours() * board.pawns()).as_int();
+    result[base + 1].mask = (board.our_knights()).as_int();
+    result[base + 2].mask = (board.ours() * board.bishops()).as_int();
+    result[base + 3].mask = (board.ours() * board.rooks()).as_int();
+    result[base + 4].mask = (board.ours() * board.queens()).as_int();
+    result[base + 5].mask = (board.our_king()).as_int();
+
+    result[base + 6].mask = (board.theirs() * board.pawns()).as_int();
+    result[base + 7].mask = (board.their_knights()).as_int();
+    result[base + 8].mask = (board.theirs() * board.bishops()).as_int();
+    result[base + 9].mask = (board.theirs() * board.rooks()).as_int();
+    result[base + 10].mask = (board.theirs() * board.queens()).as_int();
+    result[base + 11].mask = (board.their_king()).as_int();
+
+    const int repetitions = node->repetitions;
+    if (repetitions >= 1) result[base + 12].SetAll();
+    if (repetitions >= 2) result[base + 13].SetAll();
+
+    node = node->parent;
+  }
+
+  return result;
+}
+
+Move Search::GetBestMove() const {
+  std::shared_lock<std::shared_mutex> lock(nodes_mutex_);
+  Node* best_node = GetBestChild(root_node_);
+  Move move = best_node->move;
+  if (!best_node->board.flipped()) move.Mirror();
+  return move;
+}
+
+void Search::StartThreads(int how_many) {
+  std::lock_guard<std::mutex> lock(counters_mutex_);
+  while (threads_.size() < how_many) {
+    threads_.emplace_back([&]() { this->Worker(); });
+  }
+}
+
+void Search::Stop() {
+  std::lock_guard<std::mutex> lock(counters_mutex_);
+  stop_ = true;
+}
+
+void Search::Abort() {
+  std::lock_guard<std::mutex> lock(counters_mutex_);
+  responded_bestmove_ = true;
+  stop_ = true;
+}
+
+void Search::AbortAndWait() {
+  {
+    std::lock_guard<std::mutex> lock(counters_mutex_);
+    responded_bestmove_ = true;
+    stop_ = true;
+  }
+  while (!threads_.empty()) {
+    threads_.back().join();
+    threads_.pop_back();
+  }
+}
+
+Search::~Search() { AbortAndWait(); }
+
+}  // namespace lczero

--- a/lc0/src/mcts/search.h
+++ b/lc0/src/mcts/search.h
@@ -1,0 +1,104 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <functional>
+#include <shared_mutex>
+#include <thread>
+#include "mcts/node.h"
+#include "neural/network.h"
+#include "uciloop.h"
+#include "ucioptions.h"
+
+namespace lczero {
+
+struct SearchLimits {
+  std::int64_t nodes = -1;
+  std::int64_t time_ms = -1;
+};
+
+class Search {
+ public:
+  Search(Node* root_node, NodePool* node_pool, const Network* network,
+         BestMoveInfo::Callback best_move_callback,
+         UciInfo::Callback info_callback, const SearchLimits& limits,
+         UciOptions* uci_options);
+
+  ~Search();
+
+  // Populates UciOptions with search parameters.
+  static void PopulateUciParams(UciOptions* options);
+
+  // Starts worker threads and returns immediately.
+  void StartThreads(int how_many);
+
+  // Stops search. At the end bestmove will be returned. The function is not
+  // blocking, so it returns before search is actually done.
+  void Stop();
+  // Stops search, but does not return bestmove. The function is not blocking.
+  void Abort();
+  // Aborts the search, and blocks until all worker thread finish.
+  void AbortAndWait();
+
+  // Returns best move, from the point of view of white player.
+  Move GetBestMove() const;
+
+ private:
+  // Can run several copies of it in separate threads.
+  void Worker();
+
+  uint64_t GetTimeSinceStart() const;
+  void MaybeTriggerStop();
+  void MaybeOutputInfo();
+
+  void SendUciInfo();  // Requires nodes_mutex_ to be held.
+
+  Node* PickNodeToExtend(Node* node);
+  InputPlanes EncodeNode(const Node* node);
+  void ExtendNode(Node* node);
+
+  std::mutex counters_mutex_;
+  bool stop_ = false;
+  bool responded_bestmove_ = false;
+  std::vector<std::thread> threads_;
+
+  Node* root_node_;
+  NodePool* node_pool_;
+
+  mutable std::shared_mutex nodes_mutex_;
+  const Network* network_;
+  const SearchLimits limits_;
+  const std::chrono::steady_clock::time_point start_time_;
+  Node* best_move_node_ = nullptr;
+  Node* last_outputted_best_move_node_ = nullptr;
+  UciInfo uci_info_;
+  uint64_t total_nodes_ = 0;
+
+  BestMoveInfo::Callback best_move_callback_;
+  UciInfo::Callback info_callback_;
+
+  // External parameters.
+  const int kMiniBatchSize;
+  const float kCpuct;
+  const bool kPopulateMoves;
+  const bool kFlipHistory;
+  const bool kFlipMove;
+};
+
+}  // namespace lczero

--- a/lc0/src/neural/loader.cc
+++ b/lc0/src/neural/loader.cc
@@ -1,0 +1,138 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "neural/loader.h"
+#include <algorithm>
+#include <experimental/filesystem>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include "utils/exception.h"
+
+namespace lczero {
+
+FloatVectors LoadFloatsFromFile(const std::string& filename) {
+  FloatVectors res;
+
+  std::ifstream file(filename.c_str());
+  std::string line;
+  while (std::getline(file, line)) {
+    FloatVector vec;
+
+    std::istringstream iss(line);
+    float val;
+    while (iss >> val) {
+      vec.push_back(val);
+    }
+    if (!iss.eof()) throw Exception("Cannot read weights from " + filename);
+
+    if (!vec.empty()) {
+      res.emplace_back(std::move(vec));
+    }
+  }
+  if (!file.eof()) throw Exception("Cannot read weights from " + filename);
+
+  return res;
+}
+
+namespace {
+void PopulateLastIntoVector(FloatVectors* vecs, Weights::Vec* out) {
+  *out = std::move(vecs->back());
+  vecs->pop_back();
+}
+
+void PopulateConvBlockWeights(FloatVectors* vecs, Weights::ConvBlock* block) {
+  PopulateLastIntoVector(vecs, &block->bn_stddivs);
+  PopulateLastIntoVector(vecs, &block->bn_means);
+  PopulateLastIntoVector(vecs, &block->biases);
+  PopulateLastIntoVector(vecs, &block->weights);
+}
+}  // namespace
+
+Weights LoadWeightsFromFile(const std::string& filename) {
+  FloatVectors vecs = LoadFloatsFromFile(filename);
+
+  if (vecs.size() <= 19)
+    throw Exception("Weithts file " + filename +
+                    " should have at least 19 lines");
+  if (vecs[0][0] != 1) throw Exception("Weights version 1 expected");
+
+  Weights result;
+  // Populating backwards.
+  PopulateLastIntoVector(&vecs, &result.ip2_val_b);
+  PopulateLastIntoVector(&vecs, &result.ip2_val_w);
+  PopulateLastIntoVector(&vecs, &result.ip1_val_b);
+  PopulateLastIntoVector(&vecs, &result.ip1_val_w);
+  PopulateConvBlockWeights(&vecs, &result.value);
+
+  PopulateLastIntoVector(&vecs, &result.ip_pol_b);
+  PopulateLastIntoVector(&vecs, &result.ip_pol_w);
+  PopulateConvBlockWeights(&vecs, &result.policy);
+
+  // Version, Input + all the residual should be left.
+  if ((vecs.size() - 5) % 8 != 0)
+    throw Exception("Bad number of lines in weights file");
+
+  const int num_residual = (vecs.size() - 5) / 8;
+  result.residual.resize(num_residual);
+  for (int i = num_residual - 1; i >= 0; --i) {
+    PopulateConvBlockWeights(&vecs, &result.residual[i].conv2);
+    PopulateConvBlockWeights(&vecs, &result.residual[i].conv1);
+  }
+
+  PopulateConvBlockWeights(&vecs, &result.input);
+  return result;
+}
+
+std::string DiscoveryWeightsFile(const std::string& binary_name) {
+  const int kMinFileSize = 30000000;
+
+  using namespace std::experimental::filesystem;
+  std::string path = binary_name;
+  auto pos = path.find_last_of("\\/");
+  if (pos != std::string::npos) {
+    path.resize(pos);
+  } else {
+    path = ".";
+  }
+
+  std::vector<std::pair<file_time_type, std::string>> candidates;
+  for (const auto& file : recursive_directory_iterator(
+           path, directory_options::skip_permission_denied)) {
+    if (!is_regular_file(file.path())) continue;
+    if (file_size(file.path()) < kMinFileSize) continue;
+    candidates.emplace_back(last_write_time(file.path()), file.path());
+  }
+
+  std::sort(candidates.rbegin(), candidates.rend());
+
+  for (const auto& candidate : candidates) {
+    std::ifstream file(candidate.second.c_str());
+    int val = 0;
+    file >> val;
+    if (!file.fail() && val == 1) {
+      std::cerr << "Found network file: " << candidate.second << std::endl;
+      return candidate.second;
+    }
+  }
+
+  throw Exception("Network weights file not found.");
+  return {};
+}
+
+}  // namespace lczero

--- a/lc0/src/neural/loader.h
+++ b/lc0/src/neural/loader.h
@@ -1,0 +1,42 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "neural/network.h"
+
+namespace lczero {
+
+using FloatVector = std::vector<float>;
+using FloatVectors = std::vector<FloatVector>;
+
+// Read space separated file of floats and return it as a vector of vectors.
+FloatVectors LoadFloatsFromFile(const std::string& filename);
+
+// Read v1 weights file and fill the weights structure.
+Weights LoadWeightsFromFile(const std::string& filename);
+
+// Tries to find a file which looks like a weights file, and located in
+// directory of binary_name or one of subdirectories. If there are several such
+// files, returns one which has the latest modification date.
+std::string DiscoveryWeightsFile(const std::string& binary_name);
+
+}  // namespace lczero

--- a/lc0/src/neural/network.h
+++ b/lc0/src/neural/network.h
@@ -1,0 +1,98 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace lczero {
+
+const int kInputPlanes = 120;
+
+struct Weights {
+  using Vec = std::vector<float>;
+  struct ConvBlock {
+    Vec weights;
+    Vec biases;
+    Vec bn_means;
+    Vec bn_stddivs;
+  };
+
+  struct Residual {
+    ConvBlock conv1;
+    ConvBlock conv2;
+  };
+
+  // Input convnet.
+  ConvBlock input;
+
+  // Residual tower.
+  std::vector<Residual> residual;
+
+  // Policy head
+  ConvBlock policy;
+  Vec ip_pol_w;
+  Vec ip_pol_b;
+
+  // Value head
+  ConvBlock value;
+  Vec ip1_val_w;
+  Vec ip1_val_b;
+  Vec ip2_val_w;
+  Vec ip2_val_b;
+};
+
+// All input planes are 64 value vectors, every element of which is either
+// 0 or some value, unique for the plane. Therefore, input is defined as
+// a bitmask showing where to set the value, and the value itself.
+struct InputPlane {
+  InputPlane() = default;
+  void SetAll() { mask = ~0ull; }
+  void Fill(float val) {
+    SetAll();
+    value = val;
+  }
+  std::uint64_t mask = 0ull;
+  float value = 1.0f;
+};
+using InputPlanes = std::vector<InputPlane>;
+
+// An interface to implement by computing backends.
+class NetworkComputation {
+ public:
+  // Adds a sample to the batch.
+  virtual void AddInput(InputPlanes&& input) = 0;
+  // Do the computation.
+  virtual void ComputeBlocking() = 0;
+  // Returns how many times AddInput() was called.
+  virtual int GetBatchSize() const = 0;
+  // Returns Q value of @sample.
+  virtual float GetQVal(int sample) const = 0;
+  // Returns P value @move_id of @sample.
+  virtual float GetPVal(int sample, int move_id) const = 0;
+  virtual ~NetworkComputation() {}
+};
+
+class Network {
+ public:
+  virtual std::unique_ptr<NetworkComputation> NewComputation() const = 0;
+  virtual ~Network(){};
+};
+
+}  // namespace lczero

--- a/lc0/src/neural/network_test.cc
+++ b/lc0/src/neural/network_test.cc
@@ -1,0 +1,46 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <gtest/gtest.h>
+#include "neural/loader.h"
+#include "neural/network_tf.h"
+
+namespace lczero {
+
+TEST(Network, FakeData) {
+  auto weights = LoadWeightsFromFile(
+      "../testdata/"
+      "218a136a377302cce2c645e6436b0cb8284764319046dbd5f57f7aaeb498580a");
+  auto network = MakeTensorflowNetwork(weights);
+  auto compute = network->NewComputation();
+  for (int j = 0; j < 4; ++j) {
+    InputPlanes planes(120);
+    for (int i = 0; i < 120; ++i) {
+      planes[i].mask = 0x230709012008ull;
+    }
+    compute->AddInput(std::move(planes));
+  }
+  compute->ComputeBlocking();
+}
+
+}  // namespace lczero
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/lc0/src/neural/network_tf.cc
+++ b/lc0/src/neural/network_tf.cc
@@ -1,0 +1,228 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "neural/network_tf.h"
+
+#include "utils/bititer.h"
+#include "utils/transpose.h"
+
+#include <tensorflow/cc/client/client_session.h>
+#include <tensorflow/cc/ops/standard_ops.h>
+#include <tensorflow/core/framework/tensor.h>
+
+namespace lczero {
+
+using namespace tensorflow;
+using namespace tensorflow::ops;
+
+namespace {
+
+Output MakeConst(const Scope& scope, TensorShape shape,
+                 const std::vector<float>& values,
+                 const std::vector<int>& order = {}) {
+  auto tensor = Tensor(DataType::DT_FLOAT, shape);
+  CHECK_EQ(tensor.NumElements(), values.size()) << shape.DebugString();
+
+  std::vector<int> dims;
+  for (const auto& x : shape) {
+    dims.push_back(x.size);
+  }
+  TransposeTensor(dims, order, values, tensor.flat<float>().data());
+
+  return Const(scope, tensor);
+}
+
+Output MakeVals(const Scope& scope, TensorShape shape, float val) {
+  auto tensor = Tensor(DataType::DT_FLOAT, shape);
+  std::fill_n(tensor.flat<float>().data(), tensor.NumElements(), val);
+  return Const(scope, tensor);
+}
+
+Output Zeros(const Scope& scope, TensorShape shape) {
+  return MakeVals(scope, shape, 0.0f);
+}
+
+Output Ones(const Scope& scope, TensorShape shape) {
+  return MakeVals(scope, shape, 1.0f);
+}
+
+Output MakeConvBlock(const Scope& scope, Input input, int channels,
+                     int input_channels, int output_channels,
+                     const Weights::ConvBlock& weights,
+                     Input* mixin = nullptr) {
+  auto w_conv =
+      MakeConst(scope, {channels, channels, input_channels, output_channels},
+                weights.weights, {3, 2, 0, 1});
+
+  // auto b_conv = MakeConst(scope, {output_channels}, weights.biases);
+  auto conv2d = Conv2D(scope, input, w_conv, {1, 1, 1, 1}, "SAME",
+                       Conv2D::DataFormat("NCHW"));
+
+  auto batch_norm =
+      FusedBatchNorm(scope, conv2d, Ones(scope, {output_channels}),
+                     Zeros(scope, {output_channels}),
+                     MakeConst(scope, {output_channels}, weights.bn_means),
+                     MakeConst(scope, {output_channels}, weights.bn_stddivs),
+                     FusedBatchNorm::DataFormat("NCHW").IsTraining(false))
+          .y;
+
+  if (mixin) {
+    batch_norm = Add(scope, batch_norm, *mixin);
+  }
+  return Relu(scope, batch_norm);
+}
+
+Output MakeResidualBlock(const Scope& scope, Input input, int channels,
+                         const Weights::Residual& weights) {
+  auto block1 =
+      MakeConvBlock(scope, input, 3, channels, channels, weights.conv1);
+  auto block2 = MakeConvBlock(scope, block1, 3, channels, channels,
+                              weights.conv2, &input);
+  return block2;
+}
+
+std::pair<Output, Output> MakeNetwork(const Scope& scope, Input input,
+                                      const Weights& weights) {
+  const int filters = weights.input.weights.size() / 120 / 9;
+
+  // Input convolution.
+  auto flow = MakeConvBlock(scope, input, 3, 120, filters, weights.input);
+
+  // Residual tower
+  for (const auto& block : weights.residual) {
+    flow = MakeResidualBlock(scope, flow, filters, block);
+  }
+
+  // Policy head
+  auto conv_pol = MakeConvBlock(scope, flow, 1, filters, 32, weights.policy);
+  conv_pol = Reshape(scope, conv_pol, Const(scope, {-1, 32 * 8 * 8}));
+  auto ip_pol_w = MakeConst(scope, {32 * 8 * 8, 1924}, weights.ip_pol_w);
+  auto ip_pol_b = MakeConst(scope, {1924}, weights.ip_pol_b);
+  auto policy_fc = Add(scope, MatMul(scope, conv_pol, ip_pol_w), ip_pol_b);
+  auto policy_head = Softmax(scope, policy_fc);
+
+  // Value head
+  auto conv_val = MakeConvBlock(scope, flow, 1, filters, 32, weights.value);
+  conv_val = Reshape(scope, conv_val, Const(scope, {-1, 32 * 8 * 8}));
+  auto ip1_val_w = MakeConst(scope, {32 * 8 * 8, 128}, weights.ip1_val_w);
+  auto ip1_val_b = MakeConst(scope, {128}, weights.ip1_val_b);
+  auto value_flow =
+      Relu(scope, Add(scope, MatMul(scope, conv_val, ip1_val_w), ip1_val_b));
+  auto ip2_val_w = MakeConst(scope, {128, 1}, weights.ip2_val_w);
+  auto ip2_val_b = MakeConst(scope, {1}, weights.ip2_val_b);
+  auto value_head =
+      Tanh(scope, Add(scope, MatMul(scope, value_flow, ip2_val_w), ip2_val_b));
+
+  return {policy_head, value_head};
+}
+
+class TFNetworkComputation;
+class TFNetwork : public Network {
+ public:
+  TFNetwork(const Weights& weights);
+
+  std::unique_ptr<NetworkComputation> NewComputation() const override;
+
+  tensorflow::Status Compute(tensorflow::Tensor& input,
+                             std::vector<tensorflow::Tensor>* outputs) const;
+
+ private:
+  tensorflow::Scope scope_;
+  tensorflow::ClientSession session_;
+
+  std::unique_ptr<tensorflow::ops::Placeholder> input_;
+  std::unique_ptr<tensorflow::Output> policy_head_;
+  std::unique_ptr<tensorflow::Output> value_head_;
+};
+
+class TFNetworkComputation : public NetworkComputation {
+ public:
+  TFNetworkComputation(const TFNetwork* network) : network_(network) {}
+  void AddInput(InputPlanes&& input) override {
+    raw_input_.emplace_back(input);
+  }
+  void ComputeBlocking() override {
+    PrepareInput();
+    status_ = network_->Compute(input_, &output_);
+    CHECK(status_.ok()) << status_.ToString();
+  }
+
+  int GetBatchSize() const override { return raw_input_.size(); }
+  float GetQVal(int sample) const override {
+    return output_[0].matrix<float>()(sample, 0);
+  }
+  float GetPVal(int sample, int move_id) const override {
+    return output_[1].matrix<float>()(sample, move_id);
+  }
+
+ private:
+  void PrepareInput() {
+    input_ = tensorflow::Tensor(
+        tensorflow::DataType::DT_FLOAT,
+        {static_cast<int>(raw_input_.size()), kInputPlanes, 8, 8});
+
+    auto flat = input_.flat<float>();
+    memset(flat.data(), 0, flat.size() * sizeof(*flat.data()));
+    auto iter = flat.data();
+    for (const auto& sample : raw_input_) {
+      CHECK_EQ(sample.size(), kInputPlanes);
+      for (const auto& plane : sample) {
+        for (auto bit : IterateBits(plane.mask)) {
+          *(iter + bit) = plane.value;
+        }
+        iter += 64;
+      }
+    }
+  }
+
+  const TFNetwork* network_;
+  std::vector<InputPlanes> raw_input_;
+
+  tensorflow::Tensor input_;
+  std::vector<tensorflow::Tensor> output_;
+  tensorflow::Status status_;
+};
+
+TFNetwork::TFNetwork(const Weights& weights)
+    : scope_(Scope::NewRootScope()), session_(scope_) {
+  input_ = std::make_unique<Placeholder>(
+      scope_, DataType::DT_FLOAT, Placeholder::Shape({-1, kInputPlanes, 8, 8}));
+
+  auto output = MakeNetwork(scope_, *input_, weights);
+  CHECK(scope_.ok()) << scope_.status().ToString();
+
+  policy_head_ = std::make_unique<Output>(output.first);
+  value_head_ = std::make_unique<Output>(output.second);
+}
+
+tensorflow::Status TFNetwork::Compute(tensorflow::Tensor& input,
+                                      std::vector<Tensor>* outputs) const {
+  return session_.Run({{*input_, input}}, {*value_head_, *policy_head_},
+                      outputs);
+}
+
+std::unique_ptr<NetworkComputation> TFNetwork::NewComputation() const {
+  return std::make_unique<TFNetworkComputation>(this);
+}
+
+}  // namespace
+
+std::unique_ptr<Network> MakeTensorflowNetwork(const Weights& weights) {
+  return std::make_unique<TFNetwork>(weights);
+}
+
+}  // namespace lczero

--- a/lc0/src/neural/network_tf.h
+++ b/lc0/src/neural/network_tf.h
@@ -1,0 +1,28 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "neural/network.h"
+
+namespace lczero {
+
+// Creates tensorflow based computing backend.
+std::unique_ptr<Network> MakeTensorflowNetwork(const Weights& weights);
+
+}  // namespace lczero

--- a/lc0/src/uciloop.cc
+++ b/lc0/src/uciloop.cc
@@ -1,0 +1,210 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "uciloop.h"
+
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include "chess/board.h"
+#include "engine.h"
+#include "ucioptions.h"
+#include "utils/exception.h"
+
+namespace lczero {
+
+namespace {
+void SendResponse(const std::string& response) {
+  static std::mutex output_mutex;
+  std::lock_guard<std::mutex> lock(output_mutex);
+  std::cout << response << std::endl;
+}
+
+void SendBestMove(const BestMoveInfo& move) {
+  std::string res = "bestmove " + move.bestmove.as_string();
+  if (move.ponder) res += " ponder " + move.ponder.as_string();
+  SendResponse(res);
+}
+void SendInfo(const UciInfo& info) {
+  std::string res = "info";
+
+  if (info.depth >= 0) res += " depth " + std::to_string(info.depth);
+  if (info.seldepth >= 0) res += " seldepth " + std::to_string(info.seldepth);
+  if (info.time >= 0) res += " time " + std::to_string(info.time);
+  if (info.nodes >= 0) res += " nodes " + std::to_string(info.nodes);
+  if (info.score) res += " score cp " + std::to_string(info.score.value());
+  if (info.nps >= 0) res += " nps " + std::to_string(info.nps);
+
+  if (!info.pv.empty()) {
+    res += " pv";
+    for (const auto& move : info.pv) res += " " + move.as_string();
+  }
+  if (!info.comment.empty()) res += " string " + info.comment;
+  SendResponse(res);
+}
+}  // namespace
+
+void UciLoop(int argc, const char** argv) {
+  UciOptions options(argc, argv);
+  std::cout.setf(std::ios::unitbuf);
+  EngineController engine(SendBestMove, SendInfo);
+  engine.GetUciOptions(&options);
+  if (!options.ProcessAllFlags()) return;
+
+  std::string line;
+  bool options_sent = false;
+  while (std::getline(std::cin, line)) {
+    try {
+      if (line.empty()) continue;
+
+      const auto pos = line.find(' ');
+      std::string command;
+      std::string params;
+      if (pos == std::string::npos) {
+        command = line;
+      } else {
+        command = line.substr(0, pos);
+        params = line.substr(pos + 1);
+      }
+
+      /// uci
+      if (command == "uci") {
+        SendResponse("id name The Lc0 chess engine.");
+        SendResponse("id author The LCZero Authors.");
+        for (const auto& option : options.ListOptionsUci()) {
+          SendResponse(option);
+        }
+        SendResponse("uciok");
+        continue;
+      }
+
+      /// isready
+      if (command == "isready") {
+        engine.EnsureReady();
+        SendResponse("readyok");
+        continue;
+      }
+
+      /// setoption
+      if (command == "setoption") {
+        std::string name;
+        std::string value;
+        std::istringstream iss(params);
+        iss >> name;
+        std::getline(iss, value);
+        options.SetOption(name, value);
+        if (options_sent) {
+          options.SendOption(name);
+        }
+        continue;
+      }
+
+      /// ucinewgame
+      if (command == "ucinewgame") {
+        if (!options_sent) {
+          options.SendAllOptions();
+          options_sent = true;
+        }
+        engine.NewGame();
+        continue;
+      }
+
+      /// position
+      if (command == "position") {
+        if (!options_sent) {
+          options.SendAllOptions();
+          options_sent = true;
+        }
+        const std::string kMovesStr(" moves ");
+        std::vector<std::string> moves;
+
+        const auto pos = params.find(kMovesStr);
+        std::string fen = params.substr(0, pos);
+
+        if (fen == "startpos") {
+          fen = ChessBoard::kStartingFen;
+        } else if (fen.substr(0, 4) == "fen ") {
+          fen = fen.substr(4);
+        } else {
+          SendResponse("error Bad position specification: " + fen);
+          continue;
+        }
+        if (pos != std::string::npos) {
+          std::istringstream iss(params.substr(pos + kMovesStr.size()));
+          std::string move;
+          while (iss >> move) {
+            moves.push_back(move);
+          }
+        }
+        engine.SetPosition(fen, std::move(moves));
+        continue;
+      }
+
+      // go
+      if (command == "go") {
+        if (!options_sent) {
+          options.SendAllOptions();
+          options_sent = true;
+        }
+        GoParams go_params;
+        std::istringstream iss(params);
+        std::string token;
+        while (iss >> token) {
+          if (token == "infinite") {
+            go_params.infinite = true;
+          }
+#define OPTION(x)       \
+  if (token == #x) {    \
+    iss >> go_params.x; \
+    continue;           \
+  }
+          OPTION(wtime);
+          OPTION(btime);
+          OPTION(winc);
+          OPTION(binc);
+          OPTION(movestogo);
+          OPTION(depth);
+          OPTION(nodes);
+          OPTION(movetime);
+#undef OPTION
+          SendResponse("error Ignoring unknown go option: " + token);
+        }
+        engine.Go(go_params);
+        continue;
+      }
+
+      // stop
+      if (command == "stop") {
+        engine.Stop();
+        continue;
+      }
+
+      // quit
+      if (command == "quit") {
+        break;
+      }
+
+      SendResponse("error Unknown command: " + command);
+    } catch (Exception& ex) {
+      SendResponse(std::string("error ") + ex.what());
+    }
+  }
+}
+
+}  // namespace lczero

--- a/lc0/src/uciloop.cc
+++ b/lc0/src/uciloop.cc
@@ -103,11 +103,18 @@ void UciLoop(int argc, const char** argv) {
 
       /// setoption
       if (command == "setoption") {
-        std::string name;
-        std::string value;
-        std::istringstream iss(params);
-        iss >> name;
-        std::getline(iss, value);
+        if (params.substr(0, 5) != "name ") {
+          SendResponse("error Bad setoption command: " + line);
+          continue;
+        }
+        params = params.substr(5);
+        auto pos = params.find(" value ");
+        if (pos == std::string::npos) {
+          SendResponse("error Setoption value expected: " + line);
+          continue;
+        }
+        std::string name = params.substr(0, pos);
+        std::string value = params.substr(pos + 7);
         options.SetOption(name, value);
         if (options_sent) {
           options.SendOption(name);

--- a/lc0/src/uciloop.h
+++ b/lc0/src/uciloop.h
@@ -1,0 +1,60 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+#include "chess/bitboard.h"
+
+namespace lczero {
+
+// Implements Uci loop.
+void UciLoop(int argc, const char** argv);
+
+struct BestMoveInfo {
+  BestMoveInfo(Move bestmove) : bestmove(bestmove) {}
+  Move bestmove;
+  Move ponder;
+  using Callback = std::function<void(const BestMoveInfo&)>;
+};
+
+struct UciInfo {
+  // Full depth.
+  int depth = -1;
+  // Maximum depth.
+  int seldepth = -1;
+  // Time since start of thinking.
+  int64_t time = -1;
+  // Nodes visited.
+  int64_t nodes = -1;
+  // Nodes per second.
+  int nps = -1;
+  // Win in centipawns.
+  std::optional<int> score;
+  // Best line found. Moves are from perspective of white player.
+  std::vector<Move> pv;
+  // Freeform comment.
+  std::string comment;
+
+  using Callback = std::function<void(const UciInfo&)>;
+};
+
+}  // namespace lczero

--- a/lc0/src/ucioptions.cc
+++ b/lc0/src/ucioptions.cc
@@ -1,0 +1,248 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ucioptions.h"
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+namespace lczero {
+
+std::vector<std::string> UciOptions::ListOptionsUci() const {
+  std::vector<std::string> result;
+  for (const auto& iter : options_) {
+    result.emplace_back("option name " + iter->GetName() + " " +
+                        iter->GetOptionString());
+  }
+  return result;
+}
+
+void UciOptions::SetOption(const std::string& name, const std::string& value) {
+  auto option = FindOptionByName(name);
+  if (option) {
+    option->SetValue(value);
+  }
+}
+
+void UciOptions::SendAllOptions() {
+  for (const auto& x : options_) {
+    x->SendValue();
+  }
+}
+
+void UciOptions::SendOption(const std::string& name) {
+  auto option = FindOptionByName(name);
+  if (option) {
+    option->SendValue();
+  }
+}
+
+void UciOptions::Add(std::unique_ptr<Option> option) {
+  options_.emplace_back(std::move(option));
+}
+
+UciOptions::Option* UciOptions::FindOptionByName(
+    const std::string& name) const {
+  for (const auto& val : options_) {
+    if (val->GetName() == name) return val.get();
+  }
+  return nullptr;
+}
+
+bool UciOptions::ProcessAllFlags() {
+  for (const char **argv = argv_ + 1, **end = argv_ + argc_; argv != end;
+       ++argv) {
+    std::string param = *argv;
+    if (param == "-h" || param == "--help") {
+      ShowHelp();
+      return false;
+    }
+
+    if (param.substr(0, 2) == "--") {
+      param = param.substr(2);
+      std::string value;
+      auto pos = param.find('=');
+      if (pos != std::string::npos) {
+        value = param.substr(pos + 1);
+        param = param.substr(0, pos);
+      }
+      bool processed = false;
+      for (auto& option : options_) {
+        if (option->ProcessLongFlag(param, value)) {
+          processed = true;
+          break;
+        }
+      }
+      if (!processed) {
+        std::cerr << "Unknown command line flag: " << *argv << ".\n";
+        std::cerr << "For help run:\n  " << argv_[0] << " --help" << std::endl;
+        return false;
+      }
+      continue;
+    }
+    if (param.size() == 2 && param[0] == '-') {
+      std::string value;
+      bool processed = false;
+      if (argv + 1 != end) {
+        value = *(argv + 1);
+      }
+      for (auto& option : options_) {
+        if (option->ProcessShortFlag(param[1])) {
+          processed = true;
+          break;
+        } else if (option->ProcessShortFlagWithValue(param[1], value)) {
+          if (!value.empty()) ++argv;
+          processed = true;
+          break;
+        }
+      }
+      if (!processed) {
+        std::cerr << "Unknown command line flag: " << *argv << ".\n";
+        std::cerr << "For help run:\n  " << argv_[0] << " --help" << std::endl;
+        return false;
+      }
+      continue;
+    }
+
+    std::cerr << "Unknown command line argument: " << *argv << ".\n";
+    std::cerr << "For help run:\n  " << argv_[0] << " --help" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+namespace {
+std ::string FormatFlag(char short_flag, const std::string& long_flag,
+                        const std::string& help, const std::string& def = {}) {
+  std::ostringstream oss;
+  oss << "  ";
+  if (short_flag) {
+    oss << '-' << short_flag;
+  } else {
+    oss << "  ";
+  }
+  if (short_flag && !long_flag.empty()) {
+    oss << ",  ";
+  } else {
+    oss << "   ";
+  }
+  oss << std::setw(20) << std::left;
+  if (!short_flag && long_flag.empty()) {
+    oss << "(uci parameter)";
+  } else {
+    oss << (long_flag.empty() ? "" : "--" + long_flag);
+  }
+  oss << ' ' << help << ".\n";
+  if (!def.empty()) {
+    oss << std::string(28, ' ') << "(default: " << def << ")\n";
+  }
+  return oss.str();
+}
+
+}  // namespace
+
+bool StringOption::ProcessLongFlag(const std::string& flag,
+                                   const std::string& value) {
+  if (flag == GetLongFlag()) {
+    value_ = value;
+    return true;
+  }
+  return false;
+}
+
+bool StringOption::ProcessShortFlagWithValue(char flag,
+                                             const std::string& value) {
+  if (flag == GetShortFlag()) {
+    value_ = value;
+    return true;
+  }
+  return false;
+}
+
+std::string StringOption::GetHelp() const {
+  return FormatFlag(GetShortFlag(), GetLongFlag() + "=STRING", GetName(),
+                    value_);
+}
+
+bool SpinOption::ProcessLongFlag(const std::string& flag,
+                                 const std::string& value) {
+  if (flag == GetLongFlag()) {
+    value_ = std::stoi(value);
+    return true;
+  }
+  return false;
+}
+
+bool SpinOption::ProcessShortFlagWithValue(char flag,
+                                           const std::string& value) {
+  if (flag == GetShortFlag()) {
+    value_ = std::stoi(value);
+    return true;
+  }
+  return false;
+}
+
+std::string SpinOption::GetHelp() const {
+  std::string long_flag = GetLongFlag();
+  if (!long_flag.empty()) {
+    long_flag += "=" + std::to_string(min_) + ".." + std::to_string(max_);
+  }
+  return FormatFlag(GetShortFlag(), long_flag, GetName(),
+                    std::to_string(value_) + "  min: " + std::to_string(min_) +
+                        "  max: " + std::to_string(max_));
+}
+
+bool CheckOption::ProcessLongFlag(const std::string& flag,
+                                  const std::string& value) {
+  if (flag == GetLongFlag()) {
+    value_ = (value.empty() || value == "on" || value == "true");
+    return true;
+  }
+  if (flag == "no-" + GetLongFlag()) {
+    value_ = false;
+    return true;
+  }
+  return false;
+}
+
+bool CheckOption::ProcessShortFlag(char flag) {
+  if (flag == GetShortFlag()) {
+    value_ = !value_;
+    return true;
+  }
+  return false;
+}
+
+std::string CheckOption::GetHelp() const {
+  std::string long_flag = GetLongFlag();
+  if (!long_flag.empty()) {
+    long_flag = "[no-]" + long_flag;
+  }
+  return FormatFlag(GetShortFlag(), long_flag, GetName(),
+                    value_ ? "true" : "false");
+}
+
+void UciOptions::ShowHelp() const {
+  std::cerr << "Usage: " << argv_[0] << " [ flags... ]" << std::endl;
+  std::cerr << "\nAllowed command line flags:\n";
+  std::cerr << FormatFlag('h', "help", "Show help and exit");
+  for (const auto& option : options_) std::cerr << option->GetHelp();
+}
+
+}  // namespace lczero

--- a/lc0/src/ucioptions.h
+++ b/lc0/src/ucioptions.h
@@ -1,0 +1,198 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+#include "utils/exception.h"
+
+namespace lczero {
+
+class UciOptions {
+ public:
+  UciOptions(int argc, const char** argv) : argc_(argc), argv_(argv) {}
+
+  class Option {
+   public:
+    Option(const std::string& name, const std::string& long_flag,
+           char short_flag)
+        : name_(name), long_flag_(long_flag), short_flag_(short_flag) {}
+    virtual ~Option(){};
+
+    // Set value from string.
+    virtual void SetValue(const std::string& value) = 0;
+
+    // If has integer value, return, otherwise throw exception.
+    virtual int GetIntValue() const {
+      throw Exception("Unsupported command line value type.");
+    }
+
+    // If has string value, return, otherwise throw exception.
+    virtual std::string GetStringValue() const {
+      throw Exception("Unsupported command line value type.");
+    }
+
+    // If has boolean value, return, otherwise throw exception.
+    virtual bool GetBoolValue() const {
+      throw Exception("Unsupported command line value type.");
+    }
+
+   protected:
+    virtual const std::string& GetName() const { return name_; }
+    const std::string& GetLongFlag() const { return long_flag_; }
+    char GetShortFlag() const { return short_flag_; }
+
+   private:
+    virtual std::string GetOptionString() const = 0;
+    virtual void SendValue() const = 0;
+    virtual bool ProcessLongFlag(const std::string& flag,
+                                 const std::string& value) {
+      return false;
+    }
+    virtual bool ProcessShortFlag(char flag) { return false; }
+    virtual bool ProcessShortFlagWithValue(char flag,
+                                           const std::string& value) {
+      return false;
+    }
+    virtual std::string GetHelp() const = 0;
+
+    std::string name_;
+    std::string long_flag_;
+    char short_flag_;
+    friend class UciOptions;
+  };
+
+  // Add an option to the list of available options (from command line flags
+  // or UCI params)
+  void Add(std::unique_ptr<Option> option);
+
+  // Returns list of options in UCI format.
+  std::vector<std::string> ListOptionsUci() const;
+
+  // Set the option from string value.
+  void SetOption(const std::string& name, const std::string& value);
+  // Call option setter for this option.
+  void SendOption(const std::string& name);
+  // Call option setter all options.
+  void SendAllOptions();
+
+  const Option* GetOption(const std::string& name) const {
+    auto x = FindOptionByName(name);
+    if (!x) throw Exception("Unknown option: " + name);
+    return x;
+  }
+  int GetIntValue(const std::string& name) {
+    return GetOption(name)->GetIntValue();
+  }
+  bool GetBoolValue(const std::string& name) {
+    return GetOption(name)->GetBoolValue();
+  }
+
+  // Processes all flags. Returns false if should exit.
+  bool ProcessAllFlags();
+
+  std::string GetProgramName() const { return argv_[0]; }
+
+ private:
+  void ShowHelp() const;
+
+  Option* FindOptionByName(const std::string& name) const;
+  std::vector<std::unique_ptr<Option>> options_;
+  int argc_;
+  const char** argv_;
+};
+
+class StringOption : public UciOptions::Option {
+ public:
+  StringOption(const std::string& name, const std::string& def,
+               std::function<void(const std::string&)> setter,
+               const std::string& long_flag = {}, char short_flag = '\0')
+      : Option(name, long_flag, short_flag), value_(def), setter_(setter) {}
+
+  void SetValue(const std::string& value) override { value_ = value; }
+
+  std::string GetStringValue() const override { return value_; }
+
+ private:
+  std::string GetOptionString() const override {
+    return "type string default " + value_;
+  }
+  void SendValue() const override {
+    if (setter_) setter_(value_);
+  }
+  bool ProcessLongFlag(const std::string& flag,
+                       const std::string& value) override;
+
+  std::string GetHelp() const override;
+  bool ProcessShortFlagWithValue(char flag, const std::string& value) override;
+
+  std::string value_;
+  std::function<void(const std::string&)> setter_;
+};
+
+class SpinOption : public UciOptions::Option {
+ public:
+  SpinOption(const std::string& name, int def, int min, int max,
+             std::function<void(int)> setter, const std::string& long_flag = {},
+             char short_flag = '\0')
+      : Option(name, long_flag, short_flag),
+        value_(def),
+        min_(min),
+        max_(max),
+        setter_(setter) {}
+
+  void SetValue(const std::string& value) override {
+    value_ = std::stoi(value);
+  }
+  int GetIntValue() const override { return value_; }
+
+ private:
+  std::string GetOptionString() const override {
+    return "type string default " + std::to_string(value_) + " min " +
+           std::to_string(min_) + " max " + std::to_string(max_);
+  }
+  void SendValue() const override {
+    if (setter_) setter_(value_);
+  }
+  bool ProcessLongFlag(const std::string& flag,
+                       const std::string& value) override;
+
+  std::string GetHelp() const override;
+  bool ProcessShortFlagWithValue(char flag, const std::string& value) override;
+
+  int value_;
+  int min_;
+  int max_;
+  std::function<void(int)> setter_;
+};
+
+class CheckOption : public UciOptions::Option {
+ public:
+  CheckOption(const std::string& name, bool def,
+              std::function<void(bool)> setter,
+              const std::string& long_flag = {}, char short_flag = '\0')
+      : Option(name, long_flag, short_flag), value_(def), setter_(setter) {}
+
+  void SetValue(const std::string& value) override {
+    value_ = (value == "true");
+  }
+  bool GetBoolValue() const override { return value_; }
+
+ private:
+  std::string GetOptionString() const override {
+    return "type check default " + std::string(value_ ? "true" : "false");
+  }
+  void SendValue() const override {
+    if (setter_) setter_(value_);
+  }
+  bool ProcessLongFlag(const std::string& flag,
+                       const std::string& value) override;
+
+  std::string GetHelp() const override;
+  bool ProcessShortFlag(char flag) override;
+
+  bool value_;
+  std::function<void(bool)> setter_;
+};
+
+}  // namespace lczero

--- a/lc0/src/ucioptions.h
+++ b/lc0/src/ucioptions.h
@@ -148,7 +148,7 @@ class SpinOption : public UciOptions::Option {
 
  private:
   std::string GetOptionString() const override {
-    return "type string default " + std::to_string(value_) + " min " +
+    return "type spin default " + std::to_string(value_) + " min " +
            std::to_string(min_) + " max " + std::to_string(max_);
   }
   void SendValue() const override {

--- a/lc0/src/utils/bititer.h
+++ b/lc0/src/utils/bititer.h
@@ -1,0 +1,49 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+#include <cstdint>
+
+namespace lczero {
+
+// Iterates over all set bits of the value, lower to upper. The value of
+// dereferenced iterator is bit number (lower to upper, 0 bazed)
+template <typename T>
+class BitIterator {
+ public:
+  BitIterator(std::uint64_t value) : value_(value){};
+  bool operator!=(const BitIterator& other) { return value_ != other.value_; }
+
+  void operator++() { value_ &= (value_ - 1); }
+  T operator*() const { return __builtin_ctzll(value_); }
+
+ private:
+  std::uint64_t value_;
+};
+
+class IterateBits {
+ public:
+  IterateBits(std::uint64_t value) : value_(value) {}
+  BitIterator<int> begin() { return value_; }
+  BitIterator<int> end() { return 0; }
+
+ private:
+  std::uint64_t value_;
+};
+
+}  // namespace lczero

--- a/lc0/src/utils/exception.h
+++ b/lc0/src/utils/exception.h
@@ -1,0 +1,30 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <stdexcept>
+
+namespace lczero {
+
+// Exception to throw around.
+class Exception : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+}  // namespace lczero

--- a/lc0/src/utils/readprefmutex.h
+++ b/lc0/src/utils/readprefmutex.h
@@ -1,0 +1,52 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <atomic>
+#include <shared_mutex>
+
+namespace lczero {
+
+// Implementation of reader-preferenced shared mutex. Based on fair shared
+// mutex.
+class rp_shared_mutex {
+ public:
+  void lock() {
+    while (true) {
+      mutex_.lock();
+      if (waiting_readers_ == 0) return;
+      mutex_.unlock();
+    }
+  }
+  void unlock() { mutex_.unlock(); }
+  void lock_shared() {
+    ++waiting_readers_;
+    mutex_.lock_shared();
+  }
+  void unlock_shared() {
+    --waiting_readers_;
+    mutex_.unlock_shared();
+  }
+
+ private:
+  std::shared_mutex mutex_;
+  std::atomic<int> waiting_readers_ = 0;
+};
+
+}  // namespace lczero

--- a/lc0/src/utils/transpose.cc
+++ b/lc0/src/utils/transpose.cc
@@ -1,0 +1,44 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "utils/transpose.h"
+
+namespace lczero {
+void TransposeTensor(const std::vector<int>& dims, std::vector<int> order,
+                     const std::vector<float> from, float* to) {
+  if (order.empty()) {
+    for (int i = 0; i < dims.size(); ++i) order.push_back(dims.size() - i - 1);
+  }
+  std::vector<int> cur_idx(dims.size());
+  for (int _ = 0; _ < from.size(); ++_) {
+    size_t from_idx = 0;
+    for (int i : order) {
+      from_idx *= dims[i];
+      from_idx += cur_idx[i];
+    }
+    *to++ = from[from_idx];
+    for (int i = dims.size() - 1; i >= 0; --i) {
+      if (++cur_idx[i] == dims[i]) {
+        cur_idx[i] = 0;
+      } else {
+        break;
+      }
+    }
+  }
+}
+}  // namespace lczero

--- a/lc0/src/utils/transpose.h
+++ b/lc0/src/utils/transpose.h
@@ -1,0 +1,32 @@
+/*
+  This file is part of Leela Chess Zero.
+  Copyright (C) 2018 The LCZero Authors
+
+  Leela Chess is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Leela Chess is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Leela Chess.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <vector>
+
+namespace lczero {
+
+// Transposes flattened tensor from @from into @to. @to must have space for
+// from.size() elements.
+// @dims -- Dimensions of @from tensor. For example, {120, 60, 3, 3}
+// @order -- New-to-old dimension index mapping. For example {3, 2, 0, 1}
+void TransposeTensor(const std::vector<int>& dims, std::vector<int> order,
+                     const std::vector<float> from, float* to);
+
+}  // namespace lczero


### PR DESCRIPTION
This is a reimplementation of the engine. It currently uses tensorflow as a backend, and selfmade move generator.

# Performance

On my GTX970:

```
info depth 2 seldepth 23 time 4362 nodes 59466 score cp 3 nps 13632 pv e2e4 c7c5 g1f3 b8c6 c2c3 e7e5 d2d4 c5d4 c3d4 e5d4 f3d4 g8f6 b1c3 f8b4 d4c6 b7c6 e4e5 f6d5 c1d2 d7d6 a1b1
info depth 2 seldepth 24 time 5254 nodes 73649 score cp 3 nps 14017 pv e2e4 c7c5 g1f3 b8c6 c2c3 e7e5 d2d4 c5d4 c3d4 e5d4 f3d4 g8f6 b1c3 f8b4 d4c6 b7c6 e4e5 f6e4 d1d4 b4c3 c1d2
info depth 2 seldepth 25 time 13095 nodes 200388 score cp 2 nps 15302 pv e2e4 c7c5 g1f3 b8c6 c2c3 e7e6 d2d4 d7d5 e4e5 c8d7 g2g3 g8e7 f1g2 e7g6 h2h4 h7h6 h4h5 g6e7 d4c5 b7b6 c5b6 a7b6 b1d2
```

(vs lczero.exe:)

```
info depth 20 nodes 4329 nps 3196 score cp 2 winrate 50.75% time 1353 pv e2e4 c7c5 g1f3 e7e6 d2d4 c5d4 f3d4 g8f6 e4e5 f6e4 f1d3 e4c5
info depth 21 nodes 7702 nps 3478 score cp 2 winrate 50.73% time 2213 pv e2e4 c7c5 g1f3 e7e6 d2d4 c5d4 f3d4 g8f6 e4e5 f6e4 f1d3 d7d5 e5d6
NNCache: 2854/10000 hits/lookups = 28.5% hitrate, 7145 inserts, 7145 size
info depth 22 nodes 13631 nps 3688 score cp 2 winrate 50.80% time 3695 pv e2e4 c7c5 g1f3 e7e6 d2d4 c5d4 f3d4 g8f6 e4e5 f6e4 f1d3 e4c5 b1c3 b8c6
NNCache: 6419/20000 hits/lookups = 32.1% hitrate, 13580 inserts, 13580 size
info depth 23 nodes 24229 nps 3894 score cp 3 winrate 50.87% time 6221 pv e2e4 c7c5 g1f3 e7e6 d2d4 c5d4 f3d4 g8f6 e4e5 f6e4 f1d3 e4c5 b1c3 c5d3 d1d3
NNCache: 10313/30000 hits/lookups = 34.4% hitrate, 19686 inserts, 19686 size
NNCache: 14363/40000 hits/lookups = 35.9% hitrate, 25636 inserts, 25636 size
info depth 24 nodes 43009 nps 4129 score cp 3 winrate 50.86% time 10414 pv e2e4 c7c5 g1f3 b8c6 c2c3 e7e5 d2d4 c5d4 c3d4 e5d4 f3d4 g8f6 b1c3 f8b4 d4c6 b7c6 e4e5 f6d5 c1d2 e8g8
NNCache: 18938/50000 hits/lookups = 37.9% hitrate, 31061 inserts, 31061 size
NNCache: 23412/60000 hits/lookups = 39.0% hitrate, 36587 inserts, 36587 size
NNCache: 27605/70000 hits/lookups = 39.4% hitrate, 42394 inserts, 42394 size
info depth 25 nodes 76276 nps 4328 score cp 2 winrate 50.78% time 17621 pv e2e4 c7c5 g1f3 b8c6 c2c3 e7e5 d2d4 c5d4 c3d4 e5d4 f3d4 g8f6 b1c3 f8b4 d4c6 b7c6 e4e5 f6e4 d1d4 b4c3 b2c3
NNCache: 31823/80000 hits/lookups = 39.8% hitrate, 48176 inserts, 48176 size
NNCache: 35497/90000 hits/lookups = 39.4% hitrate, 54502 inserts, 50000 size

```


# Game performance

On the same time control and network, tensorflow version wins lczero.exe every time I tried (I tried 40/40 seconds games and 40/5 minutes)

# How to build

I used meson+ninja as a build tool as that was the only combination I’m somewhat familiar with. It totally makes sense to convert it to CMake (especially given than there are only tensorflow_cc build configs for CMake), but CMake’s docs size scared me so I decided to do that later.

Also we’ll surely need to have a windows version of it. I didn’t research much how to approach that, and I don’t have a windows machine to try, so if anyone agrees to help, I’d appreciate it.

Also for network file discovery I used std::experimental::filesystem. That’s probably not portable at all, so a separad code under #ifdef would be needed for windows there, I guess.

# Dependencies:

Tensorflow C++ headers/library

I followed instructions from here: https://github.com/FloopCZ/tensorflow_cc
It took more than hour to build (with GPU support), and generated 16GB of files in a build directory, but it worked.

# Why separate binary rather than extending the existing one

Initially my plan was to write something separately (plus write a movegen for fun), and then port features into the main lczero.exe. Now it feels to me that doing the opposite may make more sense, as there are some nice features in my implementation (network file discovery, uci params). On the other hand, people are familiar with lczero.exe implementation, so possibly merging into original lczero.exe is still better option.

# Adding more backends

It’s easy to add more computing backends (they just have to implement this https://github.com/mooskagh/leela-chess/blob/lc0_tf/lc0/src/neural/network.h#L77 interface), and I will port openCL and CPU versions from lczero.exe implementation. It’ll be possible to compile any subset of backends and choose the engine from UCI params / command line.
I’ll port openCL and Cpu implementation.

# Uci parameters

Many things can be configured through UCI parameters and many of them are available as command line params too.
   * Weights
   * Number of threads
   * (oldbug) Populate number of moves plane
   * (oldbug) Flip opponent’s history
   * (oldbug) Flip black’s move
   * Neural batch size
   * PUCT constant

# Time management

For now it just thinks for 1/20 of available time every move.

# Batches

The main reason for that fast computation seems to go from batches (by default, 32).

While batch is not full, I redo tree traversal with virtual loss added. It it happens to hit the same node, I just stop and do a smaller batch.

For every node I have two N values.  N of "finished visits" when I update Q and W (the N from paper), and N of "started visits", which I increment while traversing from root to leaves.
When computing U + Q, i use "N of started visits" inside U (but Q is W / N of finished visits). When visit is finished, both Ns are equal.

# Threads

It does support multiple threads (by default, 2), and increasing number of threads does help a little. Initially I also intended to start separate threads just for network computation but I seems that it doesn’t have much sense.

Also UCI is implemented in asynchronous way, so “go infinite” and then “stop” is supported.

# Weights file autodiscovery

When started without -w command line flag (and corresponding uci parameter), it tries to find a weights file located around binary. It searches directory of a binary (and below), and for all files >30Mb checks whether they start with “1\n”. If there are multiple such files, the latest by modification date is chosen

# Tree reuse

Is does reuse tree between moves. No NNCache though.

# What’s not there (yet)

  * Windows binary.
  * FPU reduction
  * selfplay / generating training data
  * Proper time management
  * no noise
  * no temperature
  * no gpu selection

