### PR TITLE
Add network id to graph tooltip

### DIFF
--- a/go/src/server/templates/index.tmpl
+++ b/go/src/server/templates/index.tmpl
@@ -135,6 +135,7 @@ var opt = {
 var tooltipOpt = {
 	showAllFields: false,
 	fields: [
+		{field: "id", title: "Network Id", format: ",d"},
 		{field: "net", title: "Number of trained games", format: ",d"},
 		{field: "rating", title: "Elo rating (0 = random play)"},
 		{field: "sprt", title: "SPRT"},


### PR DESCRIPTION
untested, assuming field id is there