### PR TITLE
Partial fixes for go infinite.

### DIFF
--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -251,8 +251,10 @@ void go(UCTSearch& search, BoardHistory& bh, istringstream& is) {
     Limits = LimitsType();
     string token;
 
-    if ((is >> token) && token == "infinite") Limits.infinite = 1;
-    else Limits.infinite = 0;
+    // TODO: See issue #287.
+    //if ((is >> token) && token == "infinite") Limits.infinite = 1;
+    //else Limits.infinite = 0;
+    Limits.infinite = 0;
 
     do {
         if (token == "wtime")          is >> Limits.time[WHITE];
@@ -265,8 +267,10 @@ void go(UCTSearch& search, BoardHistory& bh, istringstream& is) {
         else if (token == "movetime")  is >> Limits.movetime;
     } while (is >> token);
 
-    std::thread lol(gohelper, std::ref(search), std::ref(bh));
-    lol.detach();
+    // TODO: See issue #287.
+    //std::thread lol(gohelper, std::ref(search), std::ref(bh));
+    //lol.detach();
+    gohelper(search, bh);
 }
 
 

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -347,7 +347,7 @@ void UCTWorker::operator()() {
         if (result.valid()) {
             m_search->increment_playouts();
         }
-    } while (m_search->is_running() && !m_search->should_halt_search());
+    } while (m_search->is_running());
 }
 
 void UCTSearch::increment_playouts() {
@@ -425,8 +425,13 @@ Move UCTSearch::think(BoardHistory&& new_bh) {
         // check if we should still search
         keeprunning = is_running();
         keeprunning &= !should_halt_search();
-        keeprunning &= have_alternate_moves();
-    } while(keeprunning || Limits.infinite);
+        if (!Limits.infinite) {
+            // have_alternate_moves has the side effect
+            // of pruning moves, so be careful to not even
+            // call it when running infinite.
+            keeprunning &= have_alternate_moves();
+        }
+    } while(keeprunning);
 
     // stop the search
     m_run = false;

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -102,7 +102,7 @@ private:
     int m_maxvisits;
 
     bool quiet_ = true;
-    bool uci_stop = false;
+    std::atomic<bool> uci_stop{false};
 
     int get_search_time();
 };


### PR DESCRIPTION
Started on #287 but still crashing, needs more work.
@Akababa can you look at this?

UCTNode.cpp:334: UCTNode* UCTNode::uct_select_child(Color, bool): Assertion `best != nullptr' failed.
