### PR TITLE
Another small partial fix to go infinite.

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -499,6 +499,7 @@ int UCTSearch::get_search_time() {
 // Used to check if we've run out of time or reached out playout limit
 bool UCTSearch::should_halt_search() {
     if (uci_stop) return true;
+    if (Limits.infinite) return false;
     auto elapsed_millis = now() - m_start_time;
     return m_target_time < 0 ? pv_limit_reached()
         : m_target_time < elapsed_millis;


### PR DESCRIPTION
I've not un-commented the commented out code in UCTSearch in this PR, but if I do so I haven't yet managed to reproduce any further crashes.
However without this change infinite only runs as long as the current visit limit, which seems counter-intuitive.
(This change on its own though does mean go infinite hangs the client forever, since search is back on main thread at the moment.)