### PR TITLE
Make fpu dynamic_eval an option, and enable it.

### DIFF
--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -62,6 +62,7 @@ bool cfg_tune_only;
 float cfg_puct;
 float cfg_softmax_temp;
 float cfg_fpu_reduction;
+bool cfg_fpu_dynamic_eval;
 std::string cfg_weightsfile;
 std::string cfg_logfile;
 std::string cfg_supervise;
@@ -86,6 +87,7 @@ void Parameters::setup_default_parameters() {
     cfg_puct = 0.85f;
     cfg_softmax_temp = 1.0f;
     cfg_fpu_reduction = 0.0f;
+    cfg_fpu_dynamic_eval = true;
     cfg_root_temp_decay = 0;
     cfg_min_resign_moves = 20;
     cfg_resignpct = 10;

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -45,6 +45,7 @@ extern bool cfg_tune_only;
 extern float cfg_puct;
 extern float cfg_softmax_temp;
 extern float cfg_fpu_reduction;
+extern bool cfg_fpu_dynamic_eval;
 extern std::string cfg_logfile;
 extern std::string cfg_weightsfile;
 extern std::string cfg_supervise;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -313,7 +313,8 @@ UCTNode* UCTNode::uct_select_child(Color color, bool is_root) {
     }
 
     // Estimated eval for unknown nodes = original parent NN eval - reduction
-    auto fpu_eval = net_eval - fpu_reduction;
+    // Or curent parent eval - reduction if dynamic_eval is enabled.
+    auto fpu_eval = (cfg_fpu_dynamic_eval ? get_eval(color) : net_eval) - fpu_reduction;
 
     for (const auto& child : m_children) {
         if (!child->active()) {


### PR DESCRIPTION
So, I put in the PR to disable this last night concerned that it might have been unintended.

But I've done over 150 self play games at fixed visit count (tried 75 at 1600 and another 75 at 160 and they both agree) and there looks to be somewhere around a 50 elo gain with dynamic eval.

Rather than just revert my last PR, I've made it an config parameter - because there is the potential that it doesn't play well with fpu_reduction, and that fpu_reduction on its own might be an improvement even further still.