### PR TITLE
 Respect Limits.nodes in UCTSearch.

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -49,8 +49,6 @@ LimitsType Limits;
 
 UCTSearch::UCTSearch(BoardHistory&& bh)
     : bh_(std::move(bh)) {
-    set_playout_limit(cfg_max_playouts);
-    set_visit_limit(cfg_max_visits);
     m_root = std::make_unique<UCTNode>(MOVE_NONE, 0.0f, 0.5f);
 }
 
@@ -388,6 +386,15 @@ Move UCTSearch::think(BoardHistory&& new_bh) {
     Time.init(bh_.cur().side_to_move(), bh_.cur().game_ply());
     m_target_time = get_search_time();
     m_start_time = Limits.timeStarted();
+
+    // set up playout limits
+    if (Limits.nodes == 0) {
+        set_playout_limit(cfg_max_playouts);
+        set_visit_limit(cfg_max_visits);
+    } else {
+        set_playout_limit(Limits.nodes);
+        set_visit_limit(0);
+    }
 
     // create a sorted list of legal moves (make sure we
     // play something legal and decent even in time trouble)

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -392,8 +392,8 @@ Move UCTSearch::think(BoardHistory&& new_bh) {
         set_playout_limit(cfg_max_playouts);
         set_visit_limit(cfg_max_visits);
     } else {
-        set_playout_limit(Limits.nodes);
-        set_visit_limit(0);
+        set_playout_limit(0);
+        set_visit_limit(Limits.nodes);
     }
 
     // create a sorted list of legal moves (make sure we

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -98,8 +98,8 @@ private:
     int64_t m_target_time{0};
     int64_t m_start_time{0};
     std::atomic<bool> m_run{false};
-    int m_maxplayouts;
-    int m_maxvisits;
+    int m_maxplayouts{0};
+    int m_maxvisits{0};
 
     bool quiet_ = true;
     std::atomic<bool> uci_stop{false};


### PR DESCRIPTION
If UCI command `go nodes <N>` is issued, `<N>` will override the visit limit for that move.
Before:
```
go nodes 50
info depth 16 nodes 583 nps 1437 score cp 11 winrate 53.20% time 404 pv e4 e6 d4 d5 e5 c5 c3 cxd4 cxd4 Nc6 Nf3 Nge7 Bd3
bestmove e2e4
```
After:
```
go nodes 50
info depth 11 nodes 38 nps 325 score cp 8 winrate 52.47% time 113 pv e4 e6 d4 d5 e5 c5 c3
bestmove e2e4
```