### PR TITLE
UCI thread fixes for go infinite

### DIFF
--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -23,6 +23,8 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <mutex>
+#include <thread>
 
 #include "Movegen.h"
 #include "Parameters.h"
@@ -240,45 +242,6 @@ uint64_t UCI::perft(BoardHistory& bh, Depth depth) {
 }
 
 
-// go() is called when engine receives the "go" UCI command. The function sets
-// the thinking time and other parameters from the input string, then starts
-// the search.
-
-void gohelper(UCTSearch & search, BoardHistory &bh) {
-    Move move = search.think(bh.shallow_clone());
-
-    bh.do_move(move);
-    myprintf_so("bestmove %s\n", UCI::move(move).c_str());
-}
-
-void go(UCTSearch& search, BoardHistory& bh, istringstream& is) {
-
-    Limits = LimitsType();
-    string token;
-
-    // TODO: See issue #287.
-    //if ((is >> token) && token == "infinite") Limits.infinite = 1;
-    //else Limits.infinite = 0;
-    Limits.infinite = 0;
-
-    do {
-        if (token == "wtime")          is >> Limits.time[WHITE];
-        else if (token == "btime")     is >> Limits.time[BLACK];
-        else if (token == "winc")      is >> Limits.inc[WHITE];
-        else if (token == "binc")      is >> Limits.inc[BLACK];
-        else if (token == "movestogo") is >> Limits.movestogo;
-        else if (token == "depth")     is >> Limits.depth;
-        else if (token == "nodes")     is >> Limits.nodes;
-        else if (token == "movetime")  is >> Limits.movetime;
-    } while (is >> token);
-
-    // TODO: See issue #287.
-    //std::thread lol(gohelper, std::ref(search), std::ref(bh));
-    //lol.detach();
-    gohelper(search, bh);
-}
-
-
 /// UCI::loop() waits for a command from stdin, parses it and calls the appropriate
 /// function. Also intercepts EOF from stdin to ensure gracefully exiting if the
 /// GUI dies unexpectedly. When called with some command line arguments, e.g. to
@@ -290,6 +253,8 @@ void UCI::loop(const std::string& start) {
   BoardHistory bh;
   bh.set(Position::StartFEN);
   UCTSearch search (bh.shallow_clone());//std::make_unique<UCTSearch>(bh.shallow_clone());
+  std::thread search_thread;
+  std::mutex bh_mutex;
 
   do {
       if (start.empty() && !getline(cin, cmd)) // Block here waiting for input or EOF
@@ -316,66 +281,153 @@ void UCI::loop(const std::string& start) {
           Threads.ponder = false; // Switch to normal search
       */
 
-      if (token == "uci")             printVersion();
-      else if (token == "setoption")  setoption(is);
-      else if (token == "go")         go(search,bh,is);
-      else if (token == "stop")       search.please_stop();
-      else if (token == "perft")      uci_perft(bh, is);
-      else if (token == "position")   position(bh, is);
-      else if (token == "ucinewgame") ;
+      std::unique_lock<std::mutex> bh_guard(bh_mutex); //locking for all commands for safety, explicitly unlock when needed
+
+      auto wait_search = [&bh_guard, &search, &search_thread]() {
+          bh_guard.unlock();
+          if (Limits.infinite) search.please_stop();
+
+          if (search_thread.joinable()) search_thread.join();
+      };
+
+      auto stop_and_wait_search = [&bh_guard, &search, &search_thread] {
+          bh_guard.unlock();
+          search.please_stop();
+
+          if (search_thread.joinable()) search_thread.join();
+      };
+
+      if (token == "uci") {
+          printVersion();
+      }
+      else if (token == "setoption")  {
+          wait_search(); //blocking this to be safe
+
+          setoption(is);
+      }
+      else if (token == "go") {
+          wait_search();
+
+          Limits = LimitsType();
+
+          while (is >> token) {
+              if (token == "wtime")          is >> Limits.time[WHITE];
+              else if (token == "btime")     is >> Limits.time[BLACK];
+              else if (token == "winc")      is >> Limits.inc[WHITE];
+              else if (token == "binc")      is >> Limits.inc[BLACK];
+              else if (token == "movestogo") is >> Limits.movestogo;
+              else if (token == "depth")     is >> Limits.depth;
+              else if (token == "nodes")     is >> Limits.nodes;
+              else if (token == "movetime")  is >> Limits.movetime;
+              else if (token == "infinite")  Limits.infinite = 1;
+          };
+
+          search_thread = std::thread([&bh, &search, bhc = bh.shallow_clone(), &bh_mutex]() mutable {
+              Move move = search.think(std::move(bhc));
+              std::lock_guard<std::mutex> l(bh_mutex); //synchronizing with uci loop board history
+
+              bh.do_move(move);
+              myprintf_so("bestmove %s\n", UCI::move(move).c_str());
+          });
+      }
+      else if (token == "stop") {
+          stop_and_wait_search();
+      }
+      else if (token == "perft") {
+          stop_and_wait_search();
+
+          uci_perft(bh, is);
+      }
+      else if (token == "position") {
+          wait_search();
+
+          position(bh, is);
+      }
+      else if (token == "ucinewgame") {
+          stop_and_wait_search();
+      }
       else if (token == "isready") {
           Network::initialize();
-          myprintf_so("readyok\n");
+          myprintf_so("readyok\n"); //"readyok" can be sent also when the engine is calculating
       }
       // Additional custom non-UCI commands, mainly for debugging
-      else if (token == "train")   generate_training_games(is);
-      else if (token == "bench")   bench();
-      else if (token == "d" || token == "showboard") {
-		  std::stringstream ss;
-		  ss << bh.cur();
-		  myprintf_so("%s\n", ss.str().c_str());
-	  }
-	  else if (token == "showfen") {
-	      std::stringstream ss;
-		  ss << bh.cur().fen();
-		  myprintf_so("%s\n", ss.str().c_str());
-	  }
-	  else if (token == "showgame") {
-		  std::string result;
-		  for (const auto &p : bh.positions) {
-			  if (result == "") {
-			      result = " "; // first position has no move
-			  } else {
-				  result += UCI::move(p.get_move()) + " ";
-			  }
-		  }
-		  myprintf_so("position startpos%s\n", result.c_str());
-	  }
-	  else if (token == "showpgn") myprintf_so("%s\n", bh.pgn().c_str());
-	  else if (token == "undo") myprintf_so(bh.undo_move() ? "Undone\n" : "At first move\n");
-	  else if (token == "usermove" || token == "play") {
-		  std::string ms; is >> ms;
-		  Move m = UCI::to_move(bh.cur(), ms);
-		  if (m == MOVE_NONE) m = bh.cur().san_to_move(ms);
-		  if (m != MOVE_NONE) {
-			  bh.do_move(m);
-			  myprintf_so("usermove %s\n", UCI::move(m).c_str());
-		  }
-		  else {
-			  myprintf_so("Illegal move: %s\n", ms.c_str());
-		  }
-	  }
-	  else if (UCI::to_move(bh.cur(), token) != MOVE_NONE) {
-		  Move m = UCI::to_move(bh.cur(), token);
-		  bh.do_move(m);
-		  myprintf_so("usermove %s\n", UCI::move(m).c_str());
-	  }
-		  //else if (token == "eval")  sync_cout << Eval::trace(pos) << sync_endl;
-		  else if (token != "quit") {
-		  myprintf_so("Unknown command: %s\n", cmd.c_str());
-	  }
+      else if (token == "train") {
+          stop_and_wait_search();
+
+          generate_training_games(is);
+      }
+      else if (token == "bench") {
+          stop_and_wait_search();
+
+          bench();
+      }
+      else if (token == "d" || token == "showboard") { //bh is guarded by bh_guard
+          std::stringstream ss;
+          ss << bh.cur();
+          myprintf_so("%s\n", ss.str().c_str());
+      }
+      else if (token == "showfen") {
+          std::stringstream ss;
+          ss << bh.cur().fen();
+          myprintf_so("%s\n", ss.str().c_str());
+      }
+      else if (token == "showgame") {
+          std::string result;
+          for (const auto &p : bh.positions) {
+              if (result == "") {
+                  result = " "; // first position has no move
+              } else {
+                  result += UCI::move(p.get_move()) + " ";
+              }
+          }
+          myprintf_so("position startpos%s\n", result.c_str());
+      }
+      else if (token == "showpgn") myprintf_so("%s\n", bh.pgn().c_str());
+      else if (token == "undo") {
+          wait_search();
+
+          myprintf_so(bh.undo_move() ? "Undone\n" : "At first move\n");
+      }
+      else if (token == "usermove" || token == "play") {
+          wait_search();
+
+          std::string ms; is >> ms;
+          Move m = UCI::to_move(bh.cur(), ms);
+          if (m == MOVE_NONE) m = bh.cur().san_to_move(ms);
+          if (m != MOVE_NONE) {
+              bh.do_move(m);
+              myprintf_so("usermove %s\n", UCI::move(m).c_str());
+          }
+          else {
+              myprintf_so("Illegal move: %s\n", ms.c_str());
+          }
+      }
+      else if (UCI::to_move(bh.cur(), token) != MOVE_NONE) {
+          wait_search();
+
+          auto m = UCI::to_move(bh.cur(), token);
+
+          if (m != MOVE_NONE) { //double check in case search modified the board
+              bh.do_move(m);
+
+              myprintf_so("usermove %s\n", UCI::move(m).c_str());
+          } else {
+              myprintf_so("Illegal move: %s\n", token.c_str());
+          }
+      }
+      //else if (token == "eval")  sync_cout << Eval::trace(pos) << sync_endl;
+      else if (token != "quit") {
+          myprintf_so("Unknown command: %s\n", cmd.c_str());
+      }
 
   } while (start.empty()); // Command line args are one-shot
+
+  //cancel and wait existing search if any
+  search.please_stop();
+
+  if (search_thread.joinable()) {
+   search_thread.join();
+  }
 }
 
 /// UCI::square() converts a Square to a string in algebraic notation (g1, a7, etc.)

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -358,7 +358,7 @@ Move UCTSearch::think(BoardHistory&& new_bh) {
     auto start_nodes = m_root->count_nodes();
 #endif
 
-    uci_stop = false;
+    uci_stop.store(false, std::memory_order_seq_cst);
 
     // See if the position is in our previous search tree.
     // If not, construct a new m_root.
@@ -497,16 +497,16 @@ int UCTSearch::get_search_time() {
 
 // Used to check if we've run out of time or reached out playout limit
 bool UCTSearch::should_halt_search() {
-    if (uci_stop) return true;
+    if (uci_stop.load(std::memory_order_seq_cst)) return true;
+    if (Limits.infinite) return false;
     auto elapsed_millis = now() - m_start_time;
     return m_target_time < 0 ? pv_limit_reached()
         : m_target_time < elapsed_millis;
 }
 
 // Asks the search to stop politely
-void UCTSearch::please_stop()
-{
-    uci_stop = true;
+void UCTSearch::please_stop() {
+    uci_stop.store(true, std::memory_order_seq_cst);
 }
 
 void UCTSearch::set_playout_limit(int playouts) {


### PR DESCRIPTION
A continuation of work started by Akababa in PR293.

This is a basic approach to make go infinite work without a major rewrite to clean up UCI loop.

Crem's rewrite is a better approach and I think eventually it should move to that.

Or move the UCI loop to its own thread and push commands in a message fashion from getline in the main thread.