### PR TITLE
Improved Eval function

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -243,7 +243,7 @@ void UCTSearch::dump_analysis(int64_t elapsed, bool force_output) {
     float feval = m_root->get_eval(color);
     float winrate = 100.0f * feval;
     // UCI-like output wants a depth and a cp, so convert winrate to a cp estimate.
-    int cp = 162 * tan(3.14 * (feval - 0.5));
+    int cp = 452.7 * tan(2.41 * (feval - 0.5));
     // same for nodes to depth, assume nodes = 1.8 ^ depth.
     int depth = log(float(m_nodes)) / log(1.8);
     // To report nodes, use visits.


### PR DESCRIPTION
This is an eval curve normalized and tweaked by MTGOStark and syjytg, then modified by AiledlMorn to fit the tan function. Based on SF positions and conventional evaluations. It should scale well through all positions and phases of the game. A preview of the curve (and a very similar curve) can be found here: https://gyazo.com/a45165b24bf6f3ec42559c85e288000e