### PR TITLE
Improved Eval function

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -243,7 +243,7 @@ void UCTSearch::dump_analysis(int64_t elapsed, bool force_output) {
     float feval = m_root->get_eval(color);
     float winrate = 100.0f * feval;
     // UCI-like output wants a depth and a cp, so convert winrate to a cp estimate.
-    int cp = 162 * tan(3.14 * (feval - 0.5));
+    int cp = 300 * tan(3 * (feval - 0.5));
     // same for nodes to depth, assume nodes = 1.8 ^ depth.
     int depth = log(float(m_nodes)) / log(1.8);
     // To report nodes, use visits.


### PR DESCRIPTION
This is an eval curve determined and normalized by MTGOStark and syjytg, then fine-tuned by AiledlMorn to fit the tan function. Based on SF positions and conventional evaluations. It should scale well through all positions and phases of the game. A preview of the curve (and similar curves) can be found here: https://images-ext-2.discordapp.net/external/B3OEYfVT-bF4jn1su5vrIJyo5Op8HSJ1EdWxYwYiTKc/https/i.imgur.com/h0ZFkxf.png