### PR TITLE
Fix promotion as black

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -575,10 +575,16 @@ int Network::lookup(Move move, Color c) {
         if (c == WHITE) {
             return new_move_lookup.at(move);
         } else {
+            Move flipped_move;
+            if (type_of(move) == PROMOTION) {
+                flipped_move = make<PROMOTION>(~from_sq(move), ~to_sq(move), promotion_type(move));
+            } else {
+                flipped_move = make_move(~from_sq(move), ~to_sq(move));
+            }
             // The NN plays BLACK with the board flipped vertically,
             // And outputs the moves as if BLACK is moving up.
             // Flip the policy so the moves are normal.
-            return new_move_lookup.at(make_move(~from_sq(move), ~to_sq(move)));
+            return new_move_lookup.at(flipped_move);
         }
     }
 }


### PR DESCRIPTION
We didn't use the promotion flags when flipping the move for black.
This caused it to think all promotions were to knight.  After this fix,
in an example position, the network now finds the queen promotion
immediately: `6k1/1q3p1p/5Bp1/p1p5/1b3QP1/5P1P/1P1p4/4rNKR b - -`

Before:
```
info string   Qb6 ->     269   (V: 72.96%) (N:  2.63%) PV: Qb6 Kg2 Re2+ Kg3 c4 Bd4 Qd6 Qxd6 Bxd6+ f4 g5 Nxd2 Bxf4+ Kf3 Rxd2 Bc3 Rd3+
```

After:
```
info string  d1=Q ->     394   (V: 88.84%) (N: 76.65%) PV: d1=Q Qh6 Rxf1+ Kh2 Rxh1+ Kg3 Qbxf3+ Kh4 Qxf6+ Kg3 Qff3+ Kh4 Qxh3+ Kg5 Qdxg4+ Kf6 Qxh6 Ke7 Qe6+
```