### PR TITLE
Compatibility with Boost 1.67

### DIFF
--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -23,7 +23,14 @@
 #include <sstream>
 #include <algorithm>
 #include <boost/filesystem.hpp>
+
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106700
+#include <boost/next_prior.hpp>
+#else
 #include <boost/utility.hpp>
+#endif
+
 #include "stdlib.h"
 #include "zlib.h"
 #include "string.h"


### PR DESCRIPTION
In Boost 1.67, the boost::next method is defined in boost/next_prior.hpp
rather than in boost/utility.hpp.