### PR TITLE
Update pgn parser

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,7 +332,7 @@ void generate_supervised_data(const std::string& filename) {
       myprintf_so("Invalid game in %s\n", filename.c_str());
       break;
     }
-    myprintf_so("\rProcessed %d games", ++games);
+    myprintf_so("\rProcessed %d games\n", ++games);
     BoardHistory bh;
     bh.set(Position::StartFEN);
     for (int i = 0; i < static_cast<int>(game->bh.positions.size()) - 1; ++i) {

--- a/src/pgn.cpp
+++ b/src/pgn.cpp
@@ -60,9 +60,20 @@ std::unique_ptr<PGNGame> PGNParser::parse() {
     }
 
     // Skip the move numbers
-    if ((i % 3) == 0) {
-      ++i;
+    if (s.back() == '.') {
       continue;
+    }
+
+    // Drop annotations
+    if (s.back() == '!' || s.back() == '?') {
+      size_t len = s.length();
+      auto backIt = s.end();
+      backIt--;
+      while (*backIt == '!' || *backIt == '?') {
+        backIt--;
+        len--;
+      }
+      s = s.substr(0, len);
     }
 
     ++i;

--- a/src/pgn.cpp
+++ b/src/pgn.cpp
@@ -55,7 +55,7 @@ std::unique_ptr<PGNGame> PGNParser::parse() {
     }
 
     // Skip comments
-    if (s[0] == '{') {
+    if (s.front() == '{' || s.front() == '[' || s.back() == '}' || s.back() == ']') {
       continue;
     }
 


### PR DESCRIPTION
Update the PGN parser to correctly parse Lichess PGNs, which often include engine evaluations, clock times, and exclams as annotations. 