### PR TITLE
SMP::Lock destructor should check ownership.

### DIFF
--- a/src/SMP.cpp
+++ b/src/SMP.cpp
@@ -1,6 +1,6 @@
 /*
     This file is part of Leela Zero.
-    Copyright (C) 2017 Gian-Carlo Pascutto
+    Copyright (C) 2017-2018 Gian-Carlo Pascutto
 
     Leela Zero is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 
 #include "SMP.h"
 
+#include <cassert>
 #include <thread>
 
 SMP::Mutex::Mutex() {
@@ -30,15 +31,30 @@ SMP::Lock::Lock(Mutex & m) {
 }
 
 void SMP::Lock::lock() {
+    assert(!m_owns_lock);
     while (m_mutex->m_lock.exchange(true, std::memory_order_acquire) == true);
+    m_owns_lock = true;
 }
 
 void SMP::Lock::unlock() {
-    m_mutex->m_lock.store(false, std::memory_order_release);
+    assert(m_owns_lock);
+    auto lock_held = m_mutex->m_lock.exchange(false, std::memory_order_release);
+
+    // If this fails it means we are unlocking an unlocked lock
+#ifdef NDEBUG
+    (void)lock_held;
+#else
+    assert(lock_held);
+#endif
+    m_owns_lock = false;
 }
 
 SMP::Lock::~Lock() {
-    unlock();
+    // If we don't claim to hold the lock,
+    // don't bother trying to unlock in the destructor.
+    if (m_owns_lock) {
+        unlock();
+    }
 }
 
 int SMP::get_num_cpus() {

--- a/src/SMP.h
+++ b/src/SMP.h
@@ -1,6 +1,6 @@
 /*
     This file is part of Leela Zero.
-    Copyright (C) 2017 Gian-Carlo Pascutto
+    Copyright (C) 2017-2018 Gian-Carlo Pascutto
 
     Leela Zero is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -43,6 +43,7 @@ namespace SMP {
         void unlock();
     private:
         Mutex * m_mutex;
+        bool m_owns_lock{false};
     };
 }
 


### PR DESCRIPTION
If a thread explicitly calls unlock() then the destructor may try to
unlock it again. Check if this Lock instance owns the lock, and attempt
unlocking only if it owns it.

Fixes issue #379.