### PR TITLE
Negative Time Fix

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -493,7 +493,8 @@ int UCTSearch::get_search_time() {
     }
 
     auto search_time = Limits.movetime ? Limits.movetime : Time.optimum();
-    search_time -= cfg_lagbuffer_ms;
+    // We must ensure search time is non-negative to use time management
+    search_time = std::max(1, search_time - cfg_lagbuffer_ms);
     return search_time;
 }
 


### PR DESCRIPTION
If search time becomes negative, this causes the search to not check the time, thus forfeiting on time.