### PR TITLE
Fix client/server import paths to be absolute

### DIFF
--- a/go/src/client/main.go
+++ b/go/src/client/main.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 	"time"
 
-	"client/http"
+	client "github.com/glinscott/leela-chess/go/src/client/http"
 
 	"github.com/notnil/chess"
 )

--- a/go/src/server/cmd/bootstrap/main.go
+++ b/go/src/server/cmd/bootstrap/main.go
@@ -1,12 +1,10 @@
 package main
 
-import (
-	"server/db"
-)
+import "github.com/glinscott/leela-chess/go/src/server/db"
 
 func main() {
 	db.Init(true)
 	db.SetupDB()
-	db.CreateTrainingRun()
+	db.CreateTrainingRun("")
 	defer db.Close()
 }

--- a/go/src/server/cmd/compact_games/main.go
+++ b/go/src/server/cmd/compact_games/main.go
@@ -10,10 +10,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"server/db"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/glinscott/leela-chess/go/src/server/db"
 )
 
 func addFile(tw *tar.Writer, path string) error {
@@ -93,7 +94,7 @@ func tarGames(games []db.TrainingGame) string {
 	}
 	defer os.RemoveAll(dir)
 
-	outputPath := fmt.Sprintf("games%d.tar.gz", games[0].ID / 10000 * 10000)
+	outputPath := fmt.Sprintf("games%d.tar.gz", games[0].ID/10000*10000)
 	outputTar, err := os.Create(outputPath)
 	if err != nil {
 		log.Fatalln(err)
@@ -140,7 +141,7 @@ func deleteCompactedGames() {
 	leaveGames := 500000
 	log.Printf("Deleting from %d\n", ids[0])
 	for _, id := range ids {
-		if id + leaveGames >= ids[len(ids)-1] {
+		if id+leaveGames >= ids[len(ids)-1] {
 			log.Printf("Deleted to %d\n", id)
 			break
 		}
@@ -148,7 +149,7 @@ func deleteCompactedGames() {
 	log.Printf("Latest id %d\n", ids[len(ids)-1])
 
 	for _, id := range ids {
-		if id + leaveGames >= ids[len(ids)-1] {
+		if id+leaveGames >= ids[len(ids)-1] {
 			break
 		}
 		err := os.Remove(dir + "training." + strconv.Itoa(id) + ".gz")
@@ -169,7 +170,7 @@ func compactGames() bool {
 	if len(games) != int(numGames) {
 		return false
 	}
-	stop := int64(games[0].ID) / numGames * numGames + numGames
+	stop := int64(games[0].ID)/numGames*numGames + numGames
 	for idx, game := range games {
 		if int64(game.ID) >= stop {
 			games = games[0:idx]

--- a/go/src/server/cmd/tweaks/main.go
+++ b/go/src/server/cmd/tweaks/main.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"log"
-	"server/db"
+
+	"github.com/glinscott/leela-chess/go/src/server/db"
 )
 
 func updateNetworkCounts() {

--- a/go/src/server/main.go
+++ b/go/src/server/main.go
@@ -13,13 +13,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"server/db"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gin-contrib/multitemplate"
 	"github.com/gin-gonic/gin"
+	"github.com/glinscott/leela-chess/go/src/server/db"
 )
 
 func checkUser(c *gin.Context) (*db.User, uint64, error) {
@@ -350,7 +350,7 @@ func getNetwork(c *gin.Context) {
 	// Serve the file
 	// NOTE: Disabled due to bandwidth, re-enable this for tests...
 	// c.File(network.Path)
-	c.Redirect(http.StatusMovedPermanently, "https://s3.amazonaws.com/lczero/" + network.Path)
+	c.Redirect(http.StatusMovedPermanently, "https://s3.amazonaws.com/lczero/"+network.Path)
 }
 
 func setBestNetwork(training_id uint, network_id uint) error {

--- a/go/src/server/main_test.go
+++ b/go/src/server/main_test.go
@@ -12,15 +12,14 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"server/db"
 	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	client "github.com/glinscott/leela-chess/go/src/client/http"
+	"github.com/glinscott/leela-chess/go/src/server/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-
-	"client/http"
 )
 
 type StoreSuite struct {
@@ -197,7 +196,7 @@ func uploadTestNetwork(s *StoreSuite, contentString string, networkId int) {
 	s.w = httptest.NewRecorder()
 	content := []byte(contentString)
 	var buf bytes.Buffer
-	zw := gzip.NewWriterLevel(&buf, BestCompression)
+	zw, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
 	zw.Write(content)
 	zw.Close()
 


### PR DESCRIPTION
With the go paths set to absolute, it is possible to `go get` client or server.

This also fixes a few go formatting issues using go fmt as well as syntax errors for gzip and bootstrap