### PR TITLE
Rewrite the help messages concerning move exploration options

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,9 +79,10 @@ static std::string parse_commandline(int argc, char *argv[]) {
         ("tempdecay,d", po::value<int>(),
                        "After search is complete, adjust move probabilities to the power "
                        "of  1/temperature, where the temp depends on the specified tempdecay. "
-                       "Higher decay values are closer to normal 'best only' choice. -d 0 (temp=1) "
-                       "is equivalent to --randomize. Temp goes as ~ 1/(1+log(1+plies*decay/50)). "
-                       "-d 1 gives a move-50-temp of ~0.47. -d 1000 gives a move-50-temp of ~0.12.")
+                       "-d 0 (temp=1) is equivalent to --randomize; for higher decays, temp goes as"
+                       " 1/log(decay), so higher decay values are closer to normal 'best only' "
+                       "choice. -d 1 gives a move-50-temp of ~0.47. -d 1000 gives a move-50-temp "
+                       " of ~0.12.")
         ("seed,s", po::value<std::uint64_t>(),
                    "Random number generation seed.")
         ("weights,w", po::value<std::string>(), "File with network weights.")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,8 +70,8 @@ static std::string parse_commandline(int argc, char *argv[]) {
                        "Requires --noponder.")
         ("visits,v", po::value<int>(),
                        "Weaken engine by limiting the number of visits.")
-        ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
-                       "Resign when winrate is less than x%.")
+        //("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
+        //               "Resign when winrate is less than x%.")
         ("noise,n", "Before search begins, add Dirichlet noise to the root node policy's move "
                     "probabilities.")
         ("randomize,m", "After search is complete, select from the moves in proportion to "
@@ -88,7 +88,7 @@ static std::string parse_commandline(int argc, char *argv[]) {
         ("weights,w", po::value<std::string>(), "File with network weights.")
         ("logfile,l", po::value<std::string>(), "File to log input/output to.")
         ("quiet,q", "Disable all diagnostic output.")
-        ("noponder", "Disable thinking on opponent's time.")
+        //("noponder", "Disable thinking on opponent's time.")
         ("uci", "Don't initialize the engine until \"isready\" command is sent. Use this if your "
                 "GUI is freezing on startup.")
         ("start", po::value<std::string>(), "Start command {train, bench}.")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,10 +69,11 @@ static std::string parse_commandline(int argc, char *argv[]) {
                        "Weaken engine by limiting the number of visits.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
                        "Resign when winrate is less than x%.")
-        ("noise,n", "Apply dirichlet noise to root.")
-        ("randomize,m", "Randomize move selection at root.")
+        ("noise,n", "Before a playout, add Dirichlet noise to the root node's move probabilities.")
+        ("randomize,m", "During final move selection, select the move in proportion to estimated values (rather than 'best').")
         ("tempdecay,d", po::value<int>(),
-                       "Use decay schedule for move selection temperature.")
+                       "During final move selection, adjust move probabilities to the power of  1/temperature. "
+                       "Temp goes as ~ 1/(1+log(1+plies*decay/50)). -d 0 (temp=1) is equivalent to --randomize. -d 1 gives a move-50-temp of ~0.47. -d 10000 gives a move-50-temp of ~0.12.")
         ("seed,s", po::value<std::uint64_t>(),
                    "Random number generation seed.")
         ("weights,w", po::value<std::string>(), "File with network weights.")
@@ -169,7 +170,7 @@ static std::string parse_commandline(int argc, char *argv[]) {
             myprintf("Using %d thread(s).\n", num_threads);
             cfg_num_threads = num_threads;
         }
-        
+
     }
 
     if (vm.count("seed")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,9 +83,9 @@ static std::string parse_commandline(int argc, char *argv[]) {
         ("uci", "Don't initialize the engine until \"isready\" command is sent. Use this if your GUI is freezing on startup.")
         ("start", po::value<std::string>(), "Start command {train, bench}.")
         ("supervise", po::value<std::string>(), "Dump supervised learning data from the pgn.")
+#ifdef USE_OPENCL
         ("gpu",  po::value<std::vector<int> >(),
                 "ID of the OpenCL device(s) to use (disables autodetection).")
-#ifdef USE_OPENCL
         ("full-tuner", "Try harder to find an optimal OpenCL tuning.")
         ("tune-only", "Tune OpenCL only and then exit.")
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,7 +56,10 @@ static void license_blurb() {
 static std::string parse_commandline(int argc, char *argv[]) {
     namespace po = boost::program_options;
     // Declare the supported options.
-    po::options_description v_desc("Allowed options");
+    po::options_description v_desc("If you have further questions about what an option does, see "
+                                   "the project wiki:\n"
+                                   "https://github.com/glinscott/leela-chess/wiki\n\n"
+                                   "Allowed options");
     v_desc.add_options()
         ("help,h", "Show commandline options.")
         ("threads,t", po::value<int>()->default_value

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,18 +69,24 @@ static std::string parse_commandline(int argc, char *argv[]) {
                        "Weaken engine by limiting the number of visits.")
         ("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
                        "Resign when winrate is less than x%.")
-        ("noise,n", "Before a playout, add Dirichlet noise to the root node's move probabilities.")
-        ("randomize,m", "During final move selection, select the move in proportion to estimated values (rather than 'best').")
+        ("noise,n", "Before search begins, add Dirichlet noise to the root node policy's move "
+                    "probabilities.")
+        ("randomize,m", "After search is complete, select from the moves in proportion to "
+                        "their relative values (rather than 'best only').")
         ("tempdecay,d", po::value<int>(),
-                       "During final move selection, adjust move probabilities to the power of  1/temperature. "
-                       "Temp goes as ~ 1/(1+log(1+plies*decay/50)). -d 0 (temp=1) is equivalent to --randomize. -d 1 gives a move-50-temp of ~0.47. -d 10000 gives a move-50-temp of ~0.12.")
+                       "After search is complete, adjust move probabilities to the power "
+                       "of  1/temperature, where the temp depends on the specified tempdecay. "
+                       "Higher decay values are closer to normal 'best only' choice. -d 0 (temp=1) "
+                       "is equivalent to --randomize. Temp goes as ~ 1/(1+log(1+plies*decay/50)). "
+                       "-d 1 gives a move-50-temp of ~0.47. -d 1000 gives a move-50-temp of ~0.12.")
         ("seed,s", po::value<std::uint64_t>(),
                    "Random number generation seed.")
         ("weights,w", po::value<std::string>(), "File with network weights.")
         ("logfile,l", po::value<std::string>(), "File to log input/output to.")
         ("quiet,q", "Disable all diagnostic output.")
         ("noponder", "Disable thinking on opponent's time.")
-        ("uci", "Don't initialize the engine until \"isready\" command is sent. Use this if your GUI is freezing on startup.")
+        ("uci", "Don't initialize the engine until \"isready\" command is sent. Use this if your "
+                "GUI is freezing on startup.")
         ("start", po::value<std::string>(), "Start command {train, bench}.")
         ("supervise", po::value<std::string>(), "Dump supervised learning data from the pgn.")
 #ifdef USE_OPENCL

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ static std::string parse_commandline(int argc, char *argv[]) {
                                    "the project wiki:\n"
                                    "https://github.com/glinscott/leela-chess/wiki\n\n"
                                    "For non-deterministic play that retains strength, use "
-                                   "something like '--noise --tempdecay 100'.\n\n"
+                                   "'--noise' or '--tempdecay 10'.\n\n"
                                    "Allowed options");
     v_desc.add_options()
         ("help,h", "Show commandline options.")
@@ -68,29 +68,25 @@ static std::string parse_commandline(int argc, char *argv[]) {
                       (std::min(cfg_num_threads, cfg_max_threads)),
                       "Number of threads to use.")
         ("playouts,p", po::value<int>(),
-                       "Weaken engine by limiting the number of playouts. "
-                       /*"Requires --noponder."*/)
+                       "Weaken engine by limiting the number of playouts. ")
         ("visits,v", po::value<int>(),
                        "Weaken engine by limiting the number of visits.")
-        //("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
-        //               "Resign when winrate is less than x%.")
         ("noise,n", "Before search begins, add Dirichlet noise to the root node policy's move "
                     "probabilities.")
         ("randomize,m", "After search is complete, select from the moves in proportion to "
                         "their relative values (rather than 'best only').")
         ("tempdecay,d", po::value<int>(),
-                       "After search is complete, adjust move probabilities to the power "
-                       "of  1/temperature, where the temp depends on the specified tempdecay. "
-                       "-d 0 (temp=1) is equivalent to --randomize; for higher decays, temp scales "
-                       "as 1/log(plies*decay), so higher decay values are closer to normal "
-                       "'best only' choice. -d 1 gives a move-50-temp of ~0.47, while -d 1000 gives"
-                       " a move-50-temp of ~0.12.")
+                       "After search is complete, sometimes pick weaker moves for variety. "
+                       "Larger tempdecay values will do this less often, and the effect "
+                       "is reduced for moves later in the game. `0` is equivalent to "
+                       "--randomize and results in more random moves. This is used by "
+                       "self-play games to explore new moves. `10` is a reasonable value, "
+                       "and is used by test matches on the server for variety.")
         ("seed,s", po::value<std::uint64_t>(),
                    "Random number generation seed.")
         ("weights,w", po::value<std::string>(), "File with network weights.")
         ("logfile,l", po::value<std::string>(), "File to log input/output to.")
         ("quiet,q", "Disable all diagnostic output.")
-        //("noponder", "Disable thinking on opponent's time.")
         ("uci", "Don't initialize the engine until \"isready\" command is sent. Use this if your "
                 "GUI is freezing on startup.")
         ("start", po::value<std::string>(), "Start command {train, bench}.")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,8 @@ static std::string parse_commandline(int argc, char *argv[]) {
     po::options_description v_desc("If you have further questions about what an option does, see "
                                    "the project wiki:\n"
                                    "https://github.com/glinscott/leela-chess/wiki\n\n"
+                                   "For non-deterministic play that retains strength, use "
+                                   "something like '--noise --tempdecay 100'.\n\n"
                                    "Allowed options");
     v_desc.add_options()
         ("help,h", "Show commandline options.")
@@ -67,7 +69,7 @@ static std::string parse_commandline(int argc, char *argv[]) {
                       "Number of threads to use.")
         ("playouts,p", po::value<int>(),
                        "Weaken engine by limiting the number of playouts. "
-                       "Requires --noponder.")
+                       /*"Requires --noponder."*/)
         ("visits,v", po::value<int>(),
                        "Weaken engine by limiting the number of visits.")
         //("resignpct,r", po::value<int>()->default_value(cfg_resignpct),
@@ -79,10 +81,10 @@ static std::string parse_commandline(int argc, char *argv[]) {
         ("tempdecay,d", po::value<int>(),
                        "After search is complete, adjust move probabilities to the power "
                        "of  1/temperature, where the temp depends on the specified tempdecay. "
-                       "-d 0 (temp=1) is equivalent to --randomize; for higher decays, temp goes as"
-                       " 1/log(decay), so higher decay values are closer to normal 'best only' "
-                       "choice. -d 1 gives a move-50-temp of ~0.47. -d 1000 gives a move-50-temp "
-                       " of ~0.12.")
+                       "-d 0 (temp=1) is equivalent to --randomize; for higher decays, temp scales "
+                       "as 1/log(plies*decay), so higher decay values are closer to normal "
+                       "'best only' choice. -d 1 gives a move-50-temp of ~0.47, while -d 1000 gives"
+                       " a move-50-temp of ~0.12.")
         ("seed,s", po::value<std::uint64_t>(),
                    "Random number generation seed.")
         ("weights,w", po::value<std::string>(), "File with network weights.")


### PR DESCRIPTION
I had to ask in #dev to get any understanding of what they meant, thought it could use some improvement.

(Also includes an ancillary unrelated commit, moving --gpu inside OPENCL #ifdef. Should be both trivial and entirely noncontroversial.)