### PR TITLE
Fixed missing newline in winrate output

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -258,7 +258,7 @@ void UCTSearch::dump_analysis(int64_t elapsed, bool force_output) {
              depth, visits, 1000.0 * m_playouts / (elapsed + 1),
              cp, elapsed, pvstring.c_str());
     //winrate separate info string since it's not UCI spec
-    myprintf_so("info string winrate %5.2f%%", feval);
+    myprintf_so("info string winrate %5.2f%%\n", feval * 100.f);
 }
 
 bool UCTSearch::is_running() const {


### PR DESCRIPTION
Fixed a missing new line in winrate and multiplying by 100 feval