### PR TITLE
Implemented MultiPV in LCZero.

### DIFF
--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -71,6 +71,8 @@ FILE* cfg_logfile_handle;
 bool cfg_quiet;
 bool cfg_go_nodes_as_visits;
 
+int cfg_uci_multipv;
+
 void Parameters::setup_default_parameters() {
     cfg_allow_pondering = true;
     cfg_noinitialize = false;
@@ -102,5 +104,7 @@ void Parameters::setup_default_parameters() {
     cfg_rng_seed = 0;
     cfg_weightsfile = "weights.txt";
     cfg_go_nodes_as_visits = true;
+
+    cfg_uci_multipv = 1;
 }
 

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -54,6 +54,8 @@ extern FILE* cfg_logfile_handle;
 extern bool cfg_quiet;
 extern bool cfg_go_nodes_as_visits;
 
+extern int cfg_uci_multipv;
+
 class Parameters {
 public:
     static void setup_default_parameters();

--- a/src/UCIOption.cpp
+++ b/src/UCIOption.cpp
@@ -125,6 +125,11 @@ namespace UCI {
         }
     }
 
+    void on_multipv(const Option& o) {
+        cfg_uci_multipv = o;
+        myprintf("Set MultiPV to %d.\n", cfg_uci_multipv);
+    }
+
 /// Our case insensitive less() function as required by UCI protocol
     bool CaseInsensitiveLess::operator() (const string& s1, const string& s2) const {
 
@@ -144,6 +149,7 @@ namespace UCI {
         o["Puct"]                   << Option(std::to_string(cfg_puct).c_str(), on_puct);
         o["SlowMover"]              << Option(cfg_slowmover, 1, std::numeric_limits<int>::max(), on_slowmover);
         o["Go Nodes Visits"]        << Option(cfg_go_nodes_as_visits, on_nodes_as_vistis);
+        o["MultiPV"]                << Option(cfg_uci_multipv, 1, 500, on_multipv);
     }
 
 /// operator<<() is used to print all the options default values in chronological


### PR DESCRIPTION
Via `MultiPV` UCI option, this change enables LCZero to print multiple PVs.

However, since LCZero choose maximum visit count for deciding moves, it is not sorted by CP score. There are currently three options to address this issue.

- Just leave it unchanged. (MultiPV output looks awkward...)
- Change how CP score is computed. (How? A heuristic involving visit count doesn't sound great.)
- Change how LCZero picks its best move. (Probably the best option but it involves a lot of testing.)

All three options have their own problems so I don't know what to do from here... 😐