### PR TITLE
Allow Travis CI to test python w/ tensorflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 sudo: required
-dist: trusty
+dist: xenial
 env:
   - BUILD_TYPE=gpu
   - BUILD_TYPE=cpu
@@ -35,7 +35,7 @@ install:
   - mkdir build && cd build
 
 script:
-  - if [ "$BUILD_TYPE" == "gpu" ]; then cmake ..; make --build . --target lczero --config Release -- -j2; fi
+  - if [ "$BUILD_TYPE" == "gpu" ]; then cmake ..; cmake --build . --target lczero --config Release -- -j2; fi
   - if [ "$BUILD_TYPE" == "cpu" ]; then cmake -DFEATURE_USE_CPU_ONLY=1 ..; cmake --build . --config Release -- -j2; fi
   - if [ "$BUILD_TYPE" == "cpu" ]; then ./tests; fi
   - if [ "$BUILD_TYPE" == "training" ]; then cd ../training/tf; python3 chunkparser.py; python3 shufflebuffer.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,35 @@
-sudo: required
-
 language: cpp
-services:
-  - docker
+sudo: required
+dist: trusty
+env:
+  - BUILD_TYPE=gpu
+  - BUILD_TYPE=cpu
+  - BUILD_TYPE=training
 
-before_install:
-  - docker pull ubuntu:16.04
+compiler:
+  - gcc
+
+addons:
+  apt:
+    packages:
+      libboost-all-dev
+      libopenblas-dev
+      opencl-headers
+      ocl-icd-libopencl1
+      ocl-icd-opencl-dev
+      zlib1g-dev
+      clinfo
+      python3-dev
+      python3-pip
+
+install:
+  - clinfo
+  - pip3 install tensorflow
+  - python3 -V
+  - pip3 -V
 
 script:
-  - docker build .
+  - if [$BUILD_TYPE == gpu]; then cmake --build . --target lczero --config Release -- -j2; fi
+  - if [$BUILD_TYPE == cpu]; then cmake --build . --config Release -- -j2; fi
+  - if [$BUILD_TYPE == cpu]; then ./tests; fi
+  - if [$BUILD_TYPE == training]; then python3 training/tf/chunkparser.py; python3 training/tf/shufflebuffer.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: cpp
 sudo: required
 dist: trusty
 env:
-#  - BUILD_TYPE=gpu
-#  - BUILD_TYPE=cpu
+  - BUILD_TYPE=gpu
+  - BUILD_TYPE=cpu
   - BUILD_TYPE=training
 
 compiler:
@@ -37,4 +37,6 @@ script:
   - if [$BUILD_TYPE == gpu]; then cmake --build . --target lczero --config Release -- -j2; fi
   - if [$BUILD_TYPE == cpu]; then cmake --build . --config Release -- -j2; fi
   - if [$BUILD_TYPE == cpu]; then ./tests; fi
-  - if [$BUILD_TYPE == training]; then python3 training/tf/chunkparser.py; python3 training/tf/shufflebuffer.py; fi
+#  - if [$BUILD_TYPE == training]; then python3 training/tf/chunkparser.py; python3 training/tf/shufflebuffer.py; fi
+  - python3 training/tf/chunkparser.py
+  - python3 training/tf/shufflebuffer.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: cpp
 sudo: required
 dist: trusty
 env:
-  - BUILD_TYPE=gpu
-  - BUILD_TYPE=cpu
+#  - BUILD_TYPE=gpu
+#  - BUILD_TYPE=cpu
   - BUILD_TYPE=training
 
 compiler:
@@ -24,7 +24,8 @@ addons:
 
 install:
   - clinfo
-  - sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp34-cp34m-linux_x86_64.whl
+  - pip3 install --upgrade pip
+  - pip3 install tensorflow
   - python3 -V
   - pip3 -V
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - pip3 -V
 
 script:
-  - if ["$BUILD_TYPE" == "gpu"]; then cmake --build . --target lczero --config Release -- -j2; fi
-  - if ["$BUILD_TYPE" == "cpu"]; then cmake --build . --config Release -- -j2; fi
-  - if ["$BUILD_TYPE" == "cpu"]; then ./tests; fi
-  - if ["$BUILD_TYPE" == "training"]; then python3 training/tf/chunkparser.py; python3 training/tf/shufflebuffer.py; fi
+  - if [ "$BUILD_TYPE" == "gpu" ]; then cmake --build . --target lczero --config Release -- -j2; fi
+  - if [ "$BUILD_TYPE" == "cpu" ]; then cmake --build . --config Release -- -j2; fi
+  - if [ "$BUILD_TYPE" == "cpu" ]; then ./tests; fi
+  - if [ "$BUILD_TYPE" == "training" ]; then python3 training/tf/chunkparser.py; python3 training/tf/shufflebuffer.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ addons:
 
 install:
   - clinfo
-  - pip3 install tensorflow
+  - sudo pip3 install --upgrade https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp34-cp34m-linux_x86_64.whl
   - python3 -V
   - pip3 -V
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,9 @@ env:
 compiler:
   - gcc
 
-addons:
-  apt:
-    packages:
-      libboost-all-dev
-      libopenblas-dev
-      opencl-headers
-      ocl-icd-libopencl1
-      ocl-icd-opencl-dev
-      zlib1g-dev
-      clinfo
-      python3-pip
-      python3-dev
-      python-virtualenv
+before_install:
+  - apt-get -qq update
+  - apt-get install -y libboost-all-dev libopenblas-dev opencl-headers ocl-icd-libopencl1 ocl-icd-opencl-dev zlib1g-dev clinfo python3-pip python3-dev python-virtualenv
 
 install:
   - clinfo

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,10 @@ install:
   - pip3 install --upgrade tensorflow
   - python3 -V
   - pip3 -V
+  - mkdir build && cd build
 
 script:
   - if [ "$BUILD_TYPE" == "gpu" ]; then cmake --build . --target lczero --config Release -- -j2; fi
   - if [ "$BUILD_TYPE" == "cpu" ]; then cmake --build . --config Release -- -j2; fi
   - if [ "$BUILD_TYPE" == "cpu" ]; then ./tests; fi
-  - if [ "$BUILD_TYPE" == "training" ]; then python3 training/tf/chunkparser.py; python3 training/tf/shufflebuffer.py; fi
+  - if [ "$BUILD_TYPE" == "training" ]; then cd ../training/tf; python3 chunkparser.py; python3 shufflebuffer.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - mkdir build && cd build
 
 script:
-  - if [ "$BUILD_TYPE" == "gpu" ]; then cmake --build . --target lczero --config Release -- -j2; fi
-  - if [ "$BUILD_TYPE" == "cpu" ]; then cmake --build . --config Release -- -j2; fi
+  - if [ "$BUILD_TYPE" == "gpu" ]; then cmake ..; make --build . --target lczero --config Release -- -j2; fi
+  - if [ "$BUILD_TYPE" == "cpu" ]; then cmake -DFEATURE_USE_CPU_ONLY=1 ..; cmake --build . --config Release -- -j2; fi
   - if [ "$BUILD_TYPE" == "cpu" ]; then ./tests; fi
   - if [ "$BUILD_TYPE" == "training" ]; then cd ../training/tf; python3 chunkparser.py; python3 shufflebuffer.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,7 @@ install:
   - pip3 -V
 
 script:
-  - if [$BUILD_TYPE == gpu]; then cmake --build . --target lczero --config Release -- -j2; fi
-  - if [$BUILD_TYPE == cpu]; then cmake --build . --config Release -- -j2; fi
-  - if [$BUILD_TYPE == cpu]; then ./tests; fi
-#  - if [$BUILD_TYPE == training]; then python3 training/tf/chunkparser.py; python3 training/tf/shufflebuffer.py; fi
-  - python3 training/tf/chunkparser.py
-  - python3 training/tf/shufflebuffer.py
+  - if [$BUILD_TYPE == "gpu"]; then cmake --build . --target lczero --config Release -- -j2; fi
+  - if [$BUILD_TYPE == "cpu"]; then cmake --build . --config Release -- -j2; fi
+  - if [$BUILD_TYPE == "cpu"]; then ./tests; fi
+  - if [$BUILD_TYPE == "training"]; then python3 training/tf/chunkparser.py; python3 training/tf/shufflebuffer.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,17 @@ addons:
       ocl-icd-opencl-dev
       zlib1g-dev
       clinfo
-      python3-dev
       python3-pip
+      python3-dev
+      python-virtualenv
 
 install:
   - clinfo
-  - sudo pip3 install --upgrade pip
-  - pip3 install tensorflow
+  - mkdir ~/tensorflow
+  - virtualenv --system-site-packages -p python3 ~/tensorflow
+  - source ~/tensorflow/bin/activate
+  - easy_install -U pip
+  - pip3 install --upgrade tensorflow
   - python3 -V
   - pip3 -V
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ addons:
 
 install:
   - clinfo
-  - pip3 install --upgrade pip
+  - sudo pip3 install --upgrade pip
   - pip3 install tensorflow
   - python3 -V
   - pip3 -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - pip3 -V
 
 script:
-  - if [$BUILD_TYPE == "gpu"]; then cmake --build . --target lczero --config Release -- -j2; fi
-  - if [$BUILD_TYPE == "cpu"]; then cmake --build . --config Release -- -j2; fi
-  - if [$BUILD_TYPE == "cpu"]; then ./tests; fi
-  - if [$BUILD_TYPE == "training"]; then python3 training/tf/chunkparser.py; python3 training/tf/shufflebuffer.py; fi
+  - if ["$BUILD_TYPE" == "gpu"]; then cmake --build . --target lczero --config Release -- -j2; fi
+  - if ["$BUILD_TYPE" == "cpu"]; then cmake --build . --config Release -- -j2; fi
+  - if ["$BUILD_TYPE" == "cpu"]; then ./tests; fi
+  - if ["$BUILD_TYPE" == "training"]; then python3 training/tf/chunkparser.py; python3 training/tf/shufflebuffer.py; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,11 @@
-language: cpp
 sudo: required
-dist: xenial
-env:
-  - BUILD_TYPE=gpu
-  - BUILD_TYPE=cpu
-  - BUILD_TYPE=training
 
-compiler:
-  - gcc
+language: cpp
+services:
+  - docker
 
 before_install:
-  - apt-get -qq update
-  - apt-get install -y libboost-all-dev libopenblas-dev opencl-headers ocl-icd-libopencl1 ocl-icd-opencl-dev zlib1g-dev clinfo python3-pip python3-dev python-virtualenv
-
-install:
-  - clinfo
-  - mkdir ~/tensorflow
-  - virtualenv --system-site-packages -p python3 ~/tensorflow
-  - source ~/tensorflow/bin/activate
-  - easy_install -U pip
-  - pip3 install --upgrade tensorflow
-  - python3 -V
-  - pip3 -V
-  - mkdir build && cd build
+  - docker pull ubuntu:16.04
 
 script:
-  - if [ "$BUILD_TYPE" == "gpu" ]; then cmake ..; cmake --build . --target lczero --config Release -- -j2; fi
-  - if [ "$BUILD_TYPE" == "cpu" ]; then cmake -DFEATURE_USE_CPU_ONLY=1 ..; cmake --build . --config Release -- -j2; fi
-  - if [ "$BUILD_TYPE" == "cpu" ]; then ./tests; fi
-  - if [ "$BUILD_TYPE" == "training" ]; then cd ../training/tf; python3 chunkparser.py; python3 shufflebuffer.py; fi
+  - docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,12 @@ FROM ubuntu:16.04
 RUN apt-get -qq update
 RUN apt-get install -y cmake g++
 RUN apt-get install -y libboost-all-dev libopenblas-dev opencl-headers ocl-icd-libopencl1 ocl-icd-opencl-dev zlib1g-dev
-
-RUN mkdir -p /src/gpu/
-RUN mkdir -p /src/cpu/
+RUN apt-get install -y clinfo python3-pip python3-dev
+RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade tensorflow
+RUN clinfo
+RUN python3 -V
+RUN pip3 -V
 COPY . /src/
 
 # GPU build
@@ -19,3 +22,8 @@ WORKDIR /src/cpu/
 RUN CXX=g++ CC=gcc cmake -DFEATURE_USE_CPU_ONLY=1 ..
 RUN cmake --build . --config Release -- -j2
 RUN ./tests
+
+# PYTHON tests
+WORKDIR /src/training/tf/
+RUN python3 chunkparser.py
+RUN python3 shufflebuffer.py


### PR DESCRIPTION
Alters the Dockerfile to allow Travis CI to test python w/ tensorflow. I spent a lot of time trying to avoid using Docker, but it ended up being too much trouble trying to get things working on Trusty. Xenial is not yet supported in Travis CI as base operating system. I failed to get Virtualenv working inside Docker for tensorflow installation, so tensorflow is installed with "native" pip. The CPU-only version of tensorflow is installed as the Travis environment does not have GPU resources. (CircleCI appears to support GPU-enabled instances, if this is necessary for testing.)