### PR TITLE
Fix Visual Studio Project File for New UCIOption

### DIFF
--- a/msvc/VS2017/leela-chess.vcxproj
+++ b/msvc/VS2017/leela-chess.vcxproj
@@ -62,6 +62,7 @@
     <ClCompile Include="..\..\src\Training.cpp" />
     <ClCompile Include="..\..\src\Tuner.cpp" />
     <ClCompile Include="..\..\src\UCI.cpp" />
+    <ClCompile Include="..\..\src\UCIOption.cpp" />
     <ClCompile Include="..\..\src\UCTNode.cpp" />
     <ClCompile Include="..\..\src\UCTSearch.cpp" />
     <ClCompile Include="..\..\src\Utils.cpp" />


### PR DESCRIPTION
The include for UCIOption was missing from the project file.