### PR TITLE
Implement dynamic temperature

### DIFF
--- a/go/src/server/cmd/compact_games/main.go
+++ b/go/src/server/cmd/compact_games/main.go
@@ -42,6 +42,11 @@ func addFile(tw *tar.Writer, path string) error {
 }
 
 func tarGame(game *db.TrainingGame, dir string, tw *tar.Writer) error {
+	if len(game.Path) == 0 {
+		log.Printf("Skipping empty path\n")
+		return nil
+	}
+
 	if !strings.HasSuffix(game.Path, ".gz") {
 		log.Fatal("Not reading gz file?")
 	}

--- a/go/src/server/cmd/tweaks/main.go
+++ b/go/src/server/cmd/tweaks/main.go
@@ -51,7 +51,7 @@ func makeRunActive() {
 func newMatch() {
 	match := db.Match{
 		TrainingRunID: 1,
-		CandidateID:   138,
+		CandidateID:   154,
 		CurrentBestID: 125,
 		Done:          false,
 		GameCap:       400,

--- a/go/src/server/main.go
+++ b/go/src/server/main.go
@@ -47,7 +47,7 @@ func checkUser(c *gin.Context) (*db.User, uint64, error) {
 	if err != nil {
 		return nil, 0, errors.New("Invalid version")
 	}
-	if version < 5 {
+	if version < 7 {
 		log.Println("Rejecting old game from %s, version %d", user.Username, version)
 		return nil, 0, errors.New("\n\n\n\n\nYou must upgrade to a newer version!!\n\n\n\n\n")
 	}
@@ -58,7 +58,7 @@ func checkUser(c *gin.Context) (*db.User, uint64, error) {
 func nextGame(c *gin.Context) {
 	user, _, err := checkUser(c)
 	if err != nil {
-		log.Println(err)
+		log.Println(strings.TrimSpace(err.Error()))
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}
@@ -262,8 +262,13 @@ func uploadNetwork(c *gin.Context) {
 func uploadGame(c *gin.Context) {
 	user, version, err := checkUser(c)
 	if err != nil {
-		log.Println(err)
+		log.Println(strings.TrimSpace(err.Error()))
 		c.String(http.StatusBadRequest, err.Error())
+		return
+	}
+	if version, err := strconv.ParseFloat(c.PostForm("engineVersion")[1:], 64); err != nil || version < 0.7 - 1e-6{
+		log.Printf("Rejecting game with old lczero version %s", c.PostForm("engineVersion"))
+		c.String(http.StatusBadRequest, "\n\n\n\n\nYou must upgrade to a newer lczero version!!\n\n\n\n\n")
 		return
 	}
 
@@ -408,7 +413,7 @@ func checkMatchFinished(match_id uint) error {
 func matchResult(c *gin.Context) {
 	user, version, err := checkUser(c)
 	if err != nil {
-		log.Println(err)
+		log.Println(strings.TrimSpace(err.Error()))
 		c.String(http.StatusBadRequest, err.Error())
 		return
 	}

--- a/go/src/server/templates/index.tmpl
+++ b/go/src/server/templates/index.tmpl
@@ -1,6 +1,6 @@
 {{define "content"}}
 <div class="alert alert-danger" role="alert">
-  v0.7 is now out.  This fixes a critical training bug, please update.  Download <a href="https://github.com/glinscott/leela-chess/releases/tag/v0.7">here</a>.
+  v0.7 is now <b>required</b>!  It fixes a critical training bug.  Download <a href="https://github.com/glinscott/leela-chess/releases/tag/v0.7">here</a>.
 </div>
 
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pb-2 mb-3 border-bottom">

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -1,17 +1,17 @@
 /*
  This file is part of Leela Zero.
  Copyright (C) 2017 Gian-Carlo Pascutto
- 
+
  Leela Zero is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  Leela Zero is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -42,6 +42,7 @@ using namespace Utils;
 // Configuration flags
 bool cfg_allow_pondering;
 bool cfg_noinitialize;
+bool cfg_dynamic_temp;
 int cfg_max_threads;
 int cfg_num_threads;
 int cfg_max_playouts;
@@ -74,6 +75,7 @@ bool cfg_go_nodes_as_visits;
 void Parameters::setup_default_parameters() {
     cfg_allow_pondering = true;
     cfg_noinitialize = false;
+    cfg_dynamic_temp = false;
     int num_cpus = std::thread::hardware_concurrency();
     cfg_max_threads = std::max(1, std::min(num_cpus, MAX_CPUS));
     cfg_num_threads = 2;

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -1,17 +1,17 @@
 /*
  This file is part of Leela Zero.
  Copyright (C) 2017 Gian-Carlo Pascutto
- 
+
  Leela Zero is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  Leela Zero is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -25,6 +25,7 @@
 constexpr int MAXINT_DIV2 = std::numeric_limits<int>::max() / 2;
 extern bool cfg_allow_pondering;
 extern bool cfg_noinitialize;
+extern bool cfg_dynamic_temp;
 extern int cfg_max_threads;
 extern int cfg_num_threads;
 extern int cfg_max_playouts;

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -89,6 +89,7 @@ private:
     void dump_analysis(int64_t elapsed, bool force_output);
     Move get_best_move();
     float get_root_temperature();
+    float dynamic_temperature(float rt);
 
     BoardHistory bh_;
     Key m_prevroot_full_key{0};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -78,6 +78,7 @@ static std::string parse_commandline(int argc, char *argv[]) {
         ("weights,w", po::value<std::string>(), "File with network weights.")
         ("logfile,l", po::value<std::string>(), "File to log input/output to.")
         ("quiet,q", "Disable all diagnostic output.")
+        ("dynamictemp", "Scale temperature based upon expected value.")
         ("noponder", "Disable thinking on opponent's time.")
         ("uci", "Don't initialize the engine until \"isready\" command is sent. Use this if your GUI is freezing on startup.")
         ("start", po::value<std::string>(), "Start command {train, bench}.")
@@ -169,7 +170,7 @@ static std::string parse_commandline(int argc, char *argv[]) {
             myprintf("Using %d thread(s).\n", num_threads);
             cfg_num_threads = num_threads;
         }
-        
+
     }
 
     if (vm.count("seed")) {
@@ -220,6 +221,10 @@ static std::string parse_commandline(int argc, char *argv[]) {
         cfg_randomize = true;
         // Setting a value for temperature decay constant also activates --randomize.
         // However, time management is not deactivated by --tempdecay
+    }
+
+    if (vm.count("dynamictemp")) {
+        cfg_dynamic_temp = true;
     }
 
     if (vm.count("playouts")) {


### PR DESCRIPTION
When --dynamictemp is enabled, the temperature is reduced as
decisiveness increases.

The current implementation is a simple linear reduction up to a preset amount (currently 90%).