### PR TITLE
change `/usr/bin/bash` to `/bin/bash` in lc0 build.sh

### DIFF
--- a/lc0/build.sh
+++ b/lc0/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 rm -fr build
 CC=clang CXX=clang++ meson build --buildtype release # -Db_ndebug=true


### PR DESCRIPTION
`/usr/bin/bash` doesn't exist on my machine, but `/bin/bash` does