### PR TITLE
Tune PUCT parameter for chess.

### DIFF
--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -86,7 +86,7 @@ void Parameters::setup_default_parameters() {
     cfg_sgemm_exhaustive = false;
     cfg_tune_only = false;
 #endif
-    cfg_puct = 0.85f;
+    cfg_puct = 0.6f;
     cfg_softmax_temp = 1.0f;
     cfg_fpu_reduction = 0.0f;
     cfg_fpu_dynamic_eval = true;


### PR DESCRIPTION
CLOP tuning indicates the optimal values are around 0.4 - 0.9, with an
estimated maximum around 0.6, when measured in games with 2000-5000
playouts per move.

Verifying at faster timecontrols (600-1600 playouts) confirms this is a
strenght gain:

Score of lczero-tuned vs lczero: 188 - 72 - 184  [0.631] 444
Elo difference: 92.93 +/- 24.96
SPRT: llr 2.97, lbound -2.94, ubound 2.94 - H1 was accepted