### PR TITLE
Prolong cfg_lagbuffer to 100ms

### DIFF
--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -80,7 +80,7 @@ void Parameters::setup_default_parameters() {
 
     cfg_max_playouts = MAXINT_DIV2;
     cfg_max_visits   = 800;
-    cfg_lagbuffer_ms = 50;
+    cfg_lagbuffer_ms = 100;
 #ifdef USE_OPENCL
     cfg_gpus = { };
     cfg_sgemm_exhaustive = false;


### PR DESCRIPTION
Flagging was observed at very fast time controls on Google Compute 8-CPU instance e.g. 40 moves in 20 seconds. This is a new phenomenon between lczero 0.6 and 0.7. Flagging occurred in <10% of games at this TC.

Increasing the lag buffer to 100ms has fixed this. It is better to solve this by increasing cfg_lagbuffer than by requiring changes to slowmover by the user. The new setting seems ok down to time-controls as fast as 40 moves in 2 seconds (!). 

I suspect this was only manifesting itself when 
        else if (elapsed_millis < 1000 || playouts < 100) {
        // Until we reach 1 second or 100 playouts playout_rate
        // is not reliable, so just return max.
        return MAXINT_DIV2;

was true and no pruning was occurring.