### PR TITLE
use same dirichlet noise parameters in lc0-tf as lczero

### DIFF
--- a/lc0/src/mcts/search.cc
+++ b/lc0/src/mcts/search.cc
@@ -198,7 +198,7 @@ void Search::Worker() {
         }
         // Add Dirichlet noise if enabled and at root.
         if (kNoise && node == root_node_) {
-          ApplyDirichletNoise(node, 0.03, 0.25);
+          ApplyDirichletNoise(node, 0.25, 0.3);
         }
         ++idx_in_computation;
       }


### PR DESCRIPTION
I'm not sure if this is intentional or a typo (seems like a typo to me :stuck_out_tongue:), but the dirichlet noise parameters here don't match those at https://github.com/glinscott/leela-chess/blob/next/src/UCTSearch.cpp#L402 (in both places, function argument order is `(epsilon, alpha)`).
This commit changes the parameters so they match.