### PR TITLE
Improve layout of http://lczero.org on mobile

### DIFF
--- a/go/src/server/main.go
+++ b/go/src/server/main.go
@@ -615,7 +615,9 @@ func getProgress() ([]gin.H, error) {
 
 func filterProgress(result []gin.H) []gin.H {
 	// Show just the last 100 networks
-	result = result[len(result)-100:]
+	if len(result) > 100 {
+		result = result[len(result)-100:]
+	}
 
 	// Ensure the ordering is correct now (HACK)
 	tmp := []gin.H{}

--- a/go/src/server/templates/base.tmpl
+++ b/go/src/server/templates/base.tmpl
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=980">
     <meta name="description" content="LCZero - Chess learned from scratch">
     <meta name="author" content="Gary Linscott">
 
@@ -88,7 +88,7 @@
           </div>
         </nav>
 
-        <main role="main" class="col-9 ml-auto col-lg-10 pt-3 px-4">
+        <main role="main" class="col-10 ml-auto pt-3 px-4">
           {{template "content" .}}
         </main>
       </div>

--- a/go/src/server/templates/index.tmpl
+++ b/go/src/server/templates/index.tmpl
@@ -51,15 +51,13 @@
 {{end}}
 
 {{define "scripts"}}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vega/3.0.8/vega.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.0.3/vega-lite.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.0.0-rc7/vega-embed.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega@3.3.1"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega-lite@2.4.1"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega-embed@3.7.1"></script>
 <!-- Vega Tooltip -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/vega-tooltip/0.4.4/vega-tooltip.min.js"></script>
-<link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/vega-tooltip/0.4.4/vega-tooltip.min.css">
+<script src="https://cdn.jsdelivr.net/npm/vega-tooltip@0.9.14"></script>
 
 <!-- Graphs -->
-<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.1/Chart.min.js"></script>
 <script>
 var vlSpec = {
 	"$schema": "https://vega.github.io/schema/vega-lite/v2.0.json",
@@ -67,6 +65,7 @@ var vlSpec = {
 	"config": {
 		"point": { "size": 80 }
 	},
+	"width": 563, "height": 375,
 	"data": {"values": {{.progress}}},
 	"layer": [
 		{
@@ -100,12 +99,17 @@ var vlSpec = {
 				},
 				"color": {
 					"value": "blue"
+				},
+				"order": {
+					"field": "net", "type": "quantitative"
 				}
 			}
 		},
 		{
 			"transform": [
-				{ "filter": "datum.rating > -1" }
+				{ "filter": "datum.rating > -1" },
+				{ "calculate": "format(datum.net, ',d')", "as": "net_formatted" },
+				{ "calculate": "format(datum.rating, ',.2f')", "as": "rating_formatted" }
 			],
 			"mark": {"type": "point", "filled": true},
 			"encoding": {
@@ -136,29 +140,18 @@ var vlSpec = {
 				"shape": {
 					"field": "sprt", "type": "nominal",
 					"scale": {"range": ["circle", "triangle-down", "circle"]}
-				}
+				},
+				"tooltip": [
+					{"type": "nominal", "field": "id", "title": "Network Id"},
+					{"type": "nominal", "field": "net_formatted", "title": "Number of trained games"},
+					{"type": "nominal", "field": "rating_formatted", "title": "Elo rating (0 = random play)"},
+					{"type": "nominal", "field": "sprt", "title": "SPRT"}
+				]
 			}
 		}
 	]
 }
-var opt = {
-	mode: "vega-lite",
-	actions: false,
-	width: 600,
-	height: 400
-};
-var tooltipOpt = {
-	showAllFields: false,
-	fields: [
-		{field: "id", title: "Network Id", format: ",d"},
-		{field: "net", title: "Number of trained games", format: ",d"},
-		{field: "rating", title: "Elo rating (0 = random play)"},
-		{field: "sprt", title: "SPRT"}
-	]
-};
-vegaEmbed("#eloChart", vlSpec, opt)
-.then(function (result){
-	vegaTooltip.vegaLite(result.view, vlSpec, tooltipOpt)
-}).catch(console.error);
+vegaEmbed("#eloChart", vlSpec, { actions: false })
+.catch(console.error);
 </script>
 {{end}}


### PR DESCRIPTION
Currently the lczero.org site is a mess on mobile. The screenshot below is taken from the Chrome device emulator, but it’s just as broken on real devices.

![screen shot 2018-04-27 at 16 27 20](https://user-images.githubusercontent.com/103315/39371255-0844dde0-4a39-11e8-992e-0e4ee51c63e2.png)

This pull request makes the mobile view look like a scaled-down version of the desktop site, which although it isn’t ideal I think is unequivocally better than the status quo.

Here’s a screenshot from the same emulator after applying this:

![screen shot 2018-04-27 at 16 28 08](https://user-images.githubusercontent.com/103315/39371399-7bb120fe-4a39-11e8-9dda-ad33482d80e3.png)
