### PR TITLE
Change to use stockfish prng in the stockfish movegen code

### DIFF
--- a/src/Bitboard.cpp
+++ b/src/Bitboard.cpp
@@ -21,7 +21,7 @@
 #include <algorithm>
 
 #include "Bitboard.h"
-#include "Random.h"
+#include "Misc.h"
 
 uint8_t PopCnt16[1 << 16];
 int SquareDistance[SQUARE_NB][SQUARE_NB];
@@ -293,14 +293,14 @@ namespace {
         if (HasPext)
             continue;
 
-        Random rng(seeds[Is64Bit][rank_of(s)]);
+        PRNG rng(seeds[Is64Bit][rank_of(s)]);
 
         // Find a magic for square 's' picking up an (almost) random number
         // until we find the one that passes the verification test.
         for (int i = 0; i < size; )
         {
             for (m.magic = 0; popcount((m.magic * m.mask) >> 56) < 6; )
-                m.magic = rng.SparseRand<Bitboard>();
+                m.magic = rng.sparse_rand<Bitboard>();
 
             // A good magic must map every possible occupancy to an index that
             // looks up the correct sliding attack in the attacks[s] database.

--- a/src/Misc.h
+++ b/src/Misc.h
@@ -21,6 +21,7 @@
 #define LEELA_CHESS_MISC_H
 
 #include <chrono>
+#include <cassert>
 
 typedef std::chrono::milliseconds::rep TimePoint; // A value in milliseconds
 
@@ -29,5 +30,40 @@ inline TimePoint now() {
             (std::chrono::steady_clock::now().time_since_epoch()).count();
 }
 
+/// xorshift64star Pseudo-Random Number Generator
+/// This class is based on original code written and dedicated
+/// to the public domain by Sebastiano Vigna (2014).
+/// It has the following characteristics:
+///
+///  -  Outputs 64-bit numbers
+///  -  Passes Dieharder and SmallCrush test batteries
+///  -  Does not require warm-up, no zeroland to escape
+///  -  Internal state is a single 64-bit integer
+///  -  Period is 2^64 - 1
+///  -  Speed: 1.60 ns/call (Core i7 @3.40GHz)
+///
+/// For further analysis see
+///   <http://vigna.di.unimi.it/ftp/papers/xorshift.pdf>
+
+class PRNG {
+
+  uint64_t s;
+
+  uint64_t rand64() {
+
+    s ^= s >> 12, s ^= s << 25, s ^= s >> 27;
+    return s * 2685821657736338717LL;
+  }
+
+public:
+  PRNG(uint64_t seed) : s(seed) { assert(seed); }
+
+  template<typename T> T rand() { return T(rand64()); }
+
+  /// Special generator used to fast init magic numbers.
+  /// Output values only have 1/8th of their bits set on average.
+  template<typename T> T sparse_rand()
+  { return T(rand64() & rand64() & rand64()); }
+};
 
 #endif //LEELA_CHESS_MISC_H

--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -28,8 +28,8 @@
 #include "Bitboard.h"
 #include "Movegen.h"
 #include "Position.h"
-#include "Random.h"
 #include "UCI.h"
+#include "Misc.h"
 
 using std::string;
 
@@ -100,14 +100,14 @@ std::ostream& operator<<(std::ostream& os, const Position& pos) {
 
 void Position::init() {
 
-  Random rng(1070372);
+  PRNG rng(1070372);
 
   for (Piece pc : Pieces)
       for (Square s = SQ_A1; s <= SQ_H8; ++s)
-          Zobrist::psq[pc][s] = rng.RandInt<Key>();
+          Zobrist::psq[pc][s] = rng.rand<Key>();
 
   for (File f = FILE_A; f <= FILE_H; ++f)
-      Zobrist::enpassant[f] = rng.RandInt<Key>();
+      Zobrist::enpassant[f] = rng.rand<Key>();
 
   for (int cr = NO_CASTLING; cr <= ANY_CASTLING; ++cr)
   {
@@ -116,16 +116,16 @@ void Position::init() {
       while (b)
       {
           Key k = Zobrist::castling[1ULL << pop_lsb(&b)];
-          Zobrist::castling[cr] ^= k ? k : rng.RandInt<Key>();
+          Zobrist::castling[cr] ^= k ? k : rng.rand<Key>();
       }
   }
 
-  Zobrist::side = rng.RandInt<Key>();
+  Zobrist::side = rng.rand<Key>();
   for (int i = 0; i < 102/RULE50_SCALE; ++i) {
-      Zobrist::rule50[i] = rng.RandInt<Key>();
+      Zobrist::rule50[i] = rng.rand<Key>();
   }
   for (int i = 0; i <= 2; ++i) {
-      Zobrist::repetitions[i] = rng.RandInt<Key>();
+      Zobrist::repetitions[i] = rng.rand<Key>();
   }
 }
 


### PR DESCRIPTION
This ensures our zobrist hashes and magic bitboards are the same as stockfish (which is obviously more well tested). (May also speed up our init ever so slightly.)