### PR TITLE
lc0-tf: Fix HasMatingMaterial() and port tests from src/tests/position_test.cc.

### DIFF
--- a/lc0/src/chess/board.cc
+++ b/lc0/src/chess/board.cc
@@ -624,24 +624,22 @@ bool ChessBoard::HasMatingMaterial() const {
   int our = __builtin_popcountll(our_pieces_.as_int());
   int their = __builtin_popcountll(their_pieces_.as_int());
 #endif
-  if (our > 2 || their > 2) {
+  if (our + their < 4) {
+    // K v K, K+B v K, K+N v K.
+    return false;
+  }
+  if (!our_knights().empty() || !their_knights().empty()) {
     return true;
   }
 
-  if (our == 1 || their == 1) return false;
+  // Only kings and bishops remain.
 
-  bool odd_bishop = false;
-  bool even_bishop = false;
-  int bishop_count = 0;
-  for (auto x : bishops_) {
-    ++bishop_count;
-    if (x.as_int() % 2)
-      odd_bishop = true;
-    else
-      even_bishop = true;
-  }
-  if (bishop_count > 1 && (even_bishop != odd_bishop)) return false;
-  return true;
+  constexpr BitBoard kLightSquares(0x55AA55AA55AA55AAULL);
+  constexpr BitBoard kDarkSquares(0xAA55AA55AA55AA55ULL);
+
+  bool light_bishop = bishops_.intersects(kLightSquares);
+  bool dark_bishop = bishops_.intersects(kDarkSquares);
+  return light_bishop && dark_bishop;
 }
 
 string ChessBoard::DebugString() const {

--- a/lc0/src/chess/board_test.cc
+++ b/lc0/src/chess/board_test.cc
@@ -155,6 +155,76 @@ TEST(ChessBoard, MoveGenPosition6) {
   EXPECT_EQ(Perft(board, 4), 3894594);
 }
 
+TEST(ChessBoard, HasMatingMaterialStartPosition) {
+  ChessBoard board;
+  board.SetFromFen(ChessBoard::kStartingFen);
+  EXPECT_TRUE(board.HasMatingMaterial());
+}
+
+TEST(ChessBoard, HasMatingMaterialBareKings) {
+  ChessBoard board;
+  board.SetFromFen("8/8/8/4k3/8/8/2K5/8 w - - 0 1");
+  EXPECT_FALSE(board.HasMatingMaterial());
+}
+
+TEST(ChessBoard, HasMatingMaterialSingleMinorPiece) {
+  ChessBoard board;
+  board.SetFromFen("8/8/8/4k3/1N6/8/2K5/8 w - - 0 1");
+  EXPECT_FALSE(board.HasMatingMaterial());
+  board.SetFromFen("8/8/8/4k3/7b/8/2K5/8 w - - 0 1");
+  EXPECT_FALSE(board.HasMatingMaterial());
+}
+
+TEST(ChessBoard, HasMatingMaterialSingleMajorPieceOrPawn) {
+  ChessBoard board;
+  board.SetFromFen("8/8/8/4k3/8/5R2/2K5/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+  board.SetFromFen("8/8/8/4k3/8/5q2/2K5/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+  board.SetFromFen("8/8/8/4k3/8/5P2/2K5/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+}
+
+TEST(ChessBoard, HasMatingMaterialTwoKnights) {
+  ChessBoard board;
+  board.SetFromFen("8/8/8/3nk3/8/5N2/2K5/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+  board.SetFromFen("8/8/8/3nk3/8/5n2/2K5/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+}
+
+TEST(ChessBoard, HasMatingMaterialBishopAndKnight) {
+  ChessBoard board;
+  board.SetFromFen("8/8/8/3bk3/8/5N2/2K5/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+  board.SetFromFen("8/8/8/3Bk3/8/5N2/2K5/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+}
+
+TEST(ChessBoard, HasMatingMaterialMultipleBishopsSameColor) {
+  ChessBoard board;
+  board.SetFromFen("8/8/8/3Bk3/8/5B2/2K5/8 w - - 0 1");
+  EXPECT_FALSE(board.HasMatingMaterial());
+  board.SetFromFen("8/8/8/4kb2/8/2K2B2/8/8 w - - 0 1");
+  EXPECT_FALSE(board.HasMatingMaterial());
+  board.SetFromFen("B7/1B3b2/2B3b1/4k2b/8/8/2K5/8 w - - 0 1");
+  EXPECT_FALSE(board.HasMatingMaterial());
+  board.SetFromFen("B7/1B6/2B5/4k3/8/8/2K5/8 w - - 0 1");
+  EXPECT_FALSE(board.HasMatingMaterial());
+}
+
+TEST(ChessBoard, HasMatingMaterialMultipleBishopsNotSameColor) {
+  ChessBoard board;
+  board.SetFromFen("8/8/8/4k3/8/2K1bb2/8/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+  board.SetFromFen("8/8/8/4k3/8/2K1Bb2/8/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+  board.SetFromFen("8/8/8/4k3/8/2K2b2/5B2/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+  board.SetFromFen("B7/1B3b2/2B3b1/4k2b/7B/8/2K5/8 w - - 0 1");
+  EXPECT_TRUE(board.HasMatingMaterial());
+}
+
 }  // namespace lczero
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
@mooskagh 

1. Use bitmasks for light/dark squares. They don't correspond to odd/even numbers: a1(=0) is dark and even, a2(=8) is light and even.
2. \>2 pieces may not be enough for a mate (one side can get 2+ bishops on the same square color after underpromotion).