### PR TITLE
fix lc0 network creation in selfplay

### DIFF
--- a/lc0/src/main.cc
+++ b/lc0/src/main.cc
@@ -29,17 +29,13 @@ int main(int argc, const char** argv) {
   CommandLine::Init(argc, argv);
   CommandLine::RegisterMode("uci", "(default) Act as UCI engine");
 
-#if CUDNN_EVAL != 1
-  // self-play not supported with cudnn version (I ran into compile issues)
   CommandLine::RegisterMode("selfplay", "Play games with itself");
 
   if (CommandLine::ConsumeCommand("selfplay")) {
     // Selfplay mode.
     SelfPlayLoop loop;
     loop.RunLoop();
-  } else 
-#endif  
-  {
+  } else {
     // Consuming optional "uci" mode.
     CommandLine::ConsumeCommand("uci");
     // Ordinary UCI engine.

--- a/lc0/src/selfplay/tournament.cc
+++ b/lc0/src/selfplay/tournament.cc
@@ -131,7 +131,7 @@ SelfPlayTournament::SelfPlayTournament(const OptionsDict& options,
     OptionsDict network_options = OptionsDict::FromString(
         backend_options, &options.GetSubdict(kPlayerNames[idx]));
 
-    auto network =
+    networks_[idx] =
         NetworkFactory::Get()->Create(backend, weights, network_options);
   }
 


### PR DESCRIPTION
assign to `networks_` so selfplay doesn't crash

(sidenote: cudnn selfplay compiles/runs fine for me on gcc 7.3.0 if I get rid of the `#if` guards at https://github.com/glinscott/leela-chess/blob/next/lc0/src/main.cc#L32-L41)