### PR TITLE
#338 Issue: Re-enabling Supervised Learning.

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -108,6 +108,10 @@ size_t Network::get_format_version() {
     return m_format_version;
 }
 
+void Network::set_format_version(size_t format_version) {
+    m_format_version = format_version;
+}
+
 size_t Network::get_input_channels() {
     return m_format_version == 1 ? V1_INPUT_CHANNELS : V2_INPUT_CHANNELS;
 }

--- a/src/Network.h
+++ b/src/Network.h
@@ -106,9 +106,11 @@ public:
     static int lookup(Move move, Color c);
     static void gather_features(const BoardHistory& pos, NNPlanes& planes);
     static size_t get_format_version();
+    static void set_format_version(size_t format_version);
     static size_t get_input_channels();
     static size_t get_hist_planes();
     static size_t get_num_output_policy();
+    static void init_move_map();
 
 private:
     static bool initialized;
@@ -142,8 +144,7 @@ private:
                                    std::vector<float>& output);
     static void winograd_sgemm(const std::vector<float>& U,
                                std::vector<float>& V,
-                               std::vector<float>& M, const int C, const int K);
-    static void init_move_map();
+                               std::vector<float>& M, const int C, const int K);    
     static Netresult get_scored_moves_internal(const BoardHistory& state, NNPlanes& planes, DebugRawData* debug_data);
 #if defined(USE_BLAS)
     static void forward_cpu(std::vector<float>& input,

--- a/src/Training.cpp
+++ b/src/Training.cpp
@@ -106,13 +106,8 @@ void Training::record(const BoardHistory& state, Move move) {
     auto step = TimeStep{};
     step.to_move = state.cur().side_to_move();
     step.planes = Network::NNPlanes{};
-    Network::gather_features(state, step.planes);
-
-    // TODO: Does the SL flow require you to load a network file?
-    // Because now Network parses the file and stores m_format_version.
-    // Probably we will need a setter function
-    // e.g. Network::set_format_version(2)
-    throw std::runtime_error("Need to update SL flow");
+    Network::gather_features(state, step.planes);	
+    
     step.probabilities.resize(Network::get_num_output_policy());
     step.probabilities[Network::lookup(move, state.cur().side_to_move())] = 1.0;
     m_data.emplace_back(step);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -340,7 +340,7 @@ void generate_supervised_data(const std::string& filename) {
       Training::record(bh, move);
       bh.do_move(move);
     }
-    Training::dump_training(game->result, chunker);
+    Training::dump_training_v2(game->result, chunker);
   }
 }
 
@@ -366,13 +366,16 @@ int main(int argc, char* argv[]) {
 #endif
   thread_pool.initialize(cfg_num_threads);
   // Random::GetRng().seedrandom(cfg_rng_seed);
-  if (!cfg_noinitialize) {
-      Network::initialize();
+  if (!cfg_noinitialize && cfg_supervise.empty()) {
+    Network::initialize();
   }
 
-  if (!cfg_supervise.empty()) {
-      generate_supervised_data(cfg_supervise);
-      return 0;
+  if (!cfg_supervise.empty()) {	 
+    // Since we are generating supervised data we don't need to load and initialize a network from a file
+    Network::set_format_version(2);
+    Network::init_move_map();
+    generate_supervised_data(cfg_supervise);
+    return 0;
   }
 
   UCI::init(Options);

--- a/src/pgn.cpp
+++ b/src/pgn.cpp
@@ -22,6 +22,7 @@ std::unique_ptr<PGNGame> PGNParser::parse() {
   // Skip all the PGN headers
   std::string s;
   std::string result;
+  const std::string delimiter = ".";
   const std::string kResultToken = "[Result \"";
   for (;;) {
     getline(is_, s);
@@ -56,13 +57,27 @@ std::unique_ptr<PGNGame> PGNParser::parse() {
 
     // Skip comments
     if (s[0] == '{') {
+      do {
+        is_ >> s;
+      } while (s.back() != '}');
       continue;
     }
 
     // Skip the move numbers
     if ((i % 3) == 0) {
-      ++i;
-      continue;
+      // Some PGN files have this movement format: 1.d4 (no space after the dot) instead of 1. d4 
+      if (s.back() != '.')
+      {		
+        size_t pos = 0;
+        if ((pos = s.find(delimiter)) != std::string::npos) {
+          s = s.substr(pos + 1, std::string::npos);
+          ++i;
+        }		
+	  }	  
+      else {
+        ++i;
+        continue;
+      }            
     }
 
     ++i;


### PR DESCRIPTION
#338 Issue: Re-enabling Supervised Learning. Also fixing some pgn parser bugs:

1) Fixing a problem because some PGN files have this movement format: 1.d4 (no space after the dot) instead of 1. d4 (pgn.cpp lines 68 to 76).
2) Skipping correctly the comments. It's not enough to check for the opened char '{', we have to take care we found the closer '}' before continuing. (pgn.cpp line 59).
3) If 'cfg_supervise' is not empty we are generating supervised data and so we don't need to load and initialize a network from a file (main.cpp line 373 & 369).

I had some conflicts with the current pgn.cpp file but I think my changes are better than those currently in 'next' branch:
1) The current pgn.cpp does not take into account that some pgn files have this movement format: 1.d4 (no space after the dot) instead of 1. d4.

For example, imagine this: 1.e4 e6 2.d4 d5 3.Nd2 c5...

In the current file we have:

```
// Skip the move numbers
    if (s.back() == '.') {
      continue;
    }
```

but this fails because as I say there is some PGN files with a valid format where the first movement is right after the dot without space:  1.d4 (no space after the dot) instead of 1. d4

I fixed this using the master version of the pgn.cpp file and doing the changes needed to attend both formats (with and without spaces after the dot).

2) Also the way it tries to skip comments  is wrong since some comments have various words and we need to iterate until we find the end char '}' because in other case after continue; we get with "is_ >> s;" a word in the middle of the comment. The correct way is to iterate like I did in line 59.

For example, imagine this: ...48. Rh1 Rxd7 49. Re1 {Black forfeits on time} 1-0

In the current file we have:

```
// Skip comments
    if (s.front() == '{' || s.front() == '[' || s.back() == '}' || s.back() == ']') {
      continue;
    }
```
But then after the "continue;" the line:

`is_ >> s;`

would fill s = "forfeits" what it's wrong.

We need to do the do{..}while(..); I used to reach the '}' before continuing. 
