### PR TITLE
Update lc0 eval conversion to new formula

### DIFF
--- a/lc0/src/mcts/search.cc
+++ b/lc0/src/mcts/search.cc
@@ -387,7 +387,7 @@ void Search::SendUciInfo() REQUIRES(nodes_mutex_) {
       cache_->GetSize() * 1000LL / std::max(cache_->GetCapacity(), 1);
   uci_info_.nps =
       uci_info_.time ? (total_playouts_ * 1000 / uci_info_.time) : 0;
-  uci_info_.score = -191 * log(2 / (best_move_node_->q * 0.99 + 1) - 1);
+  uci_info_.score = 290.680623072 * tan(1.548090806 * best_move_node_->q);
   uci_info_.pv.clear();
 
   for (Node* iter = best_move_node_; iter; iter = GetBestChild(iter)) {


### PR DESCRIPTION
Based off `290.680623072 * tan(3.096181612 * (x - 0.5))`.
Modified to scale to lc0 eval which is `-1 .. 1` instead of `0 .. 1`

`lczero_eval = (lc0_eval + 1)/2` so formula becomes `290.680623072 * tan(1.548090806 * x)`