### PR TITLE
Rename public-facing code/variables from "visits" to "nodes"

### DIFF
--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -1,17 +1,17 @@
 /*
  This file is part of Leela Zero.
  Copyright (C) 2017 Gian-Carlo Pascutto
- 
+
  Leela Zero is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  Leela Zero is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -45,7 +45,7 @@ bool cfg_noinitialize;
 int cfg_max_threads;
 int cfg_num_threads;
 int cfg_max_playouts;
-int cfg_max_visits;
+int cfg_max_nodes;
 int cfg_lagbuffer_ms;
 int cfg_resignpct;
 int cfg_noise;
@@ -65,12 +65,12 @@ float cfg_softmax_temp;
 float cfg_fpu_reduction;
 bool cfg_fpu_dynamic_eval;
 std::string cfg_weightsfile;
-std::string cfg_syzygypath; 
+std::string cfg_syzygypath;
 std::string cfg_logfile;
 std::string cfg_supervise;
 FILE* cfg_logfile_handle;
 bool cfg_quiet;
-bool cfg_go_nodes_as_visits;
+bool cfg_go_nodes_as_playouts;
 
 void Parameters::setup_default_parameters() {
     cfg_allow_pondering = true;
@@ -80,7 +80,7 @@ void Parameters::setup_default_parameters() {
     cfg_num_threads = 2;
 
     cfg_max_playouts = MAXINT_DIV2;
-    cfg_max_visits   = 800;
+    cfg_max_nodes    = 800;
     cfg_lagbuffer_ms = 50;
 #ifdef USE_OPENCL
     cfg_gpus = { };
@@ -103,6 +103,6 @@ void Parameters::setup_default_parameters() {
     cfg_rng_seed = 0;
     cfg_weightsfile = "weights.txt";
     cfg_syzygypath = "syzygy";
-    cfg_go_nodes_as_visits = true;
+    cfg_go_nodes_as_playouts = false;
 }
 

--- a/src/Parameters.h
+++ b/src/Parameters.h
@@ -1,17 +1,17 @@
 /*
  This file is part of Leela Zero.
  Copyright (C) 2017 Gian-Carlo Pascutto
- 
+
  Leela Zero is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
- 
+
  Leela Zero is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
- 
+
  You should have received a copy of the GNU General Public License
  along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -28,7 +28,7 @@ extern bool cfg_noinitialize;
 extern int cfg_max_threads;
 extern int cfg_num_threads;
 extern int cfg_max_playouts;
-extern int cfg_max_visits;
+extern int cfg_max_nodes;
 extern int cfg_lagbuffer_ms;
 extern int cfg_resignpct;
 extern int cfg_noise;
@@ -53,7 +53,7 @@ extern std::string cfg_syzygypath;
 extern std::string cfg_supervise;
 extern FILE* cfg_logfile_handle;
 extern bool cfg_quiet;
-extern bool cfg_go_nodes_as_visits;
+extern bool cfg_go_nodes_as_playouts;
 
 class Parameters {
 public:

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -97,7 +97,7 @@ namespace {
       Limits = LimitsType();
       std::string token;
 
-      search.set_visit_limit(cfg_max_visits);
+      search.set_node_limit(cfg_max_nodes);
       search.set_playout_limit(cfg_max_playouts);
 
       while (is >> token) {
@@ -110,12 +110,12 @@ namespace {
           else if (token == "nodes")     {
               is >> Limits.nodes;
 
-              if (cfg_go_nodes_as_visits) {
-                  search.set_visit_limit(static_cast<int>(Limits.nodes));
-                  search.set_playout_limit(MAXINT_DIV2);
-              } else {
+              if (cfg_go_nodes_as_playouts) {
                   search.set_playout_limit(static_cast<int>(Limits.nodes));
-                  search.set_visit_limit(MAXINT_DIV2);
+                  search.set_node_limit(MAXINT_DIV2);
+              } else {
+                  search.set_node_limit(static_cast<int>(Limits.nodes));
+                  search.set_playout_limit(MAXINT_DIV2);
               }
           }
           else if (token == "movetime")  is >> Limits.movetime;

--- a/src/UCIOption.cpp
+++ b/src/UCIOption.cpp
@@ -115,13 +115,13 @@ namespace UCI {
         myprintf("Set cfg_slowmover to %d.\n", cfg_slowmover);
     }
 
-    void on_nodes_as_visits(const Option& o) {
-        cfg_go_nodes_as_visits = o;
+    void on_nodes_as_playouts(const Option& o) {
+        cfg_go_nodes_as_playouts = o;
 
-        if (cfg_go_nodes_as_visits) {
-            myprintf("Set go nodes to visits.\n");
-        } else {
+        if (cfg_go_nodes_as_playouts) {
             myprintf("Set go nodes to playouts.\n");
+        } else {
+            myprintf("Set go nodes to nodes.\n");
         }
     }
 
@@ -143,7 +143,7 @@ namespace UCI {
         o["FPU Dynamic Eval"]       << SilentOption(cfg_fpu_dynamic_eval, on_fpudynamiceval);
         o["Puct"]                   << Option(std::to_string(cfg_puct).c_str(), on_puct);
         o["SlowMover"]              << Option(cfg_slowmover, 1, std::numeric_limits<int>::max(), on_slowmover);
-        o["Go Nodes Visits"]        << Option(cfg_go_nodes_as_visits, on_nodes_as_visits);
+        o["GoNodesPlayouts"]        << Option(cfg_go_nodes_as_playouts, on_nodes_as_playouts);
     }
 
 /// operator<<() is used to print all the options default values in chronological

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -51,7 +51,7 @@ LimitsType Limits;
 UCTSearch::UCTSearch(BoardHistory&& bh)
     : bh_(std::move(bh)) {
     set_playout_limit(cfg_max_playouts);
-    set_visit_limit(cfg_max_visits);
+    set_node_limit(cfg_max_nodes);
     m_root = std::make_unique<UCTNode>(MOVE_NONE, 0.0f, 0.5f);
 }
 
@@ -296,7 +296,7 @@ int UCTSearch::est_playouts_left() const {
         // No time control, use playouts or visits.
         const auto playouts_left =
                 std::max(0, std::min(m_maxplayouts - playouts,
-                                     m_maxvisits - m_root->get_visits()));
+                                     m_maxnodes - m_root->get_visits()));
         return playouts_left;
     } else if (elapsed_millis < 1000 || playouts < 100) {
         // Until we reach 1 second or 100 playouts playout_rate
@@ -363,7 +363,7 @@ bool UCTSearch::have_alternate_moves() {
 
 bool UCTSearch::pv_limit_reached() const {
     return m_playouts >= m_maxplayouts
-        || m_root->get_visits() >= m_maxvisits;
+        || m_root->get_visits() >= m_maxnodes;
 }
 
 void UCTWorker::operator()() {
@@ -554,13 +554,13 @@ void UCTSearch::set_playout_limit(int playouts) {
     }
 }
 
-void UCTSearch::set_visit_limit(int visits) {
-    static_assert(std::is_convertible<decltype(visits), decltype(m_maxvisits)>::value, "Inconsistent types for visits amount.");
-    if (visits == 0) {
+void UCTSearch::set_node_limit(int nodes) {
+    static_assert(std::is_convertible<decltype(nodes), decltype(m_maxnodes)>::value, "Inconsistent types for nodes amount.");
+    if (nodes == 0) {
         // Divide max by 2 to prevent overflow when multithreading.
-        m_maxvisits = MAXINT_DIV2;
+        m_maxnodes = MAXINT_DIV2;
     } else {
-        m_maxvisits = visits;
+        m_maxnodes = nodes;
     }
 }
 

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -69,7 +69,7 @@ public:
     UCTSearch(BoardHistory&& bh);
     Move think(BoardHistory&& bh);
     void set_playout_limit(int playouts);
-    void set_visit_limit(int visits);
+    void set_node_limit(int nodes);
     void set_analyzing(bool flag);
     void set_quiet(bool flag);
     void ponder();
@@ -102,7 +102,7 @@ private:
     int64_t m_start_time{0};
     std::atomic<bool> m_run{false};
     int m_maxplayouts;
-    int m_maxvisits;
+    int m_maxnodes;
 
     bool quiet_ = true;
     std::atomic<bool> uci_stop{false};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,8 +70,8 @@ static std::string parse_commandline(int argc, char *argv[]) {
                       "Number of threads to use.")
         ("playouts,p", po::value<int>(),
                        "Weaken engine by limiting the number of playouts. ")
-        ("visits,v", po::value<int>(),
-                       "Weaken engine by limiting the number of visits.")
+        ("nodes,v", po::value<int>(),
+                       "Weaken engine by limiting the number of nodes in the tree.")
         ("noise,n", "Before search begins, add Dirichlet noise to the root node policy's move "
                     "probabilities.")
         ("randomize,m", "After search is complete, select from the moves in proportion to "
@@ -109,7 +109,10 @@ static std::string parse_commandline(int argc, char *argv[]) {
     // command line.
     po::options_description h_desc("Hidden options");
     h_desc.add_options()
-        ("arguments", po::value<std::vector<std::string>>());
+        ("arguments", po::value<std::vector<std::string>>())
+        ("visits", po::value<int>(),
+                     "Weaken engine by limiting the number of visits. This spelling is deprecated.")
+        ;
     // Parse both the above, we will check if any of the latter are present.
     po::options_description all("All options");
     all.add(v_desc).add(h_desc);
@@ -176,7 +179,7 @@ static std::string parse_commandline(int argc, char *argv[]) {
     }
 
     if (vm.count("syzygypath")) {
-        cfg_syzygypath = vm["syzygypath"].as<std::string>();        
+        cfg_syzygypath = vm["syzygypath"].as<std::string>();
     }
 
     if (vm.count("threads")) {
@@ -249,15 +252,19 @@ static std::string parse_commandline(int argc, char *argv[]) {
                      "Add --noponder if you want a weakened engine.\n");
             exit(EXIT_FAILURE);
         }
-        if (!vm.count("visits")) {
+        if (!vm.count("visits") && !vm.count("nodes")) {
             // If the user specifies playouts they probably
-            // do not want the default 800 visits.
-            cfg_max_visits = MAXINT_DIV2;
+            // do not want the default 800 nodes.
+            cfg_max_nodes = MAXINT_DIV2;
         }
     }
 
     if (vm.count("visits")) {
-        cfg_max_visits = vm["visits"].as<int>();
+        cfg_max_nodes = vm["visits"].as<int>();
+    }
+    // let deprecated spelling be overwritten by new/correct spelling
+    if (vm.count("nodes")) {
+        cfg_max_nodes = vm["nodes"].as<int>();
     }
 
     if (vm.count("resignpct")) {


### PR DESCRIPTION
The --visits option is kept as hidden for compatibility. --visits and --nodes are equivalent.

This would remove some ambiguity in public facing engine-use documentation, including what "playouts" means.

Acceptance of this PR should be accompanied by simultaneous wiki updates to reflect the change.