### PR TITLE
Move Network::initialize() to UCI::loop()

### DIFF
--- a/go/src/client/main.go
+++ b/go/src/client/main.go
@@ -135,7 +135,6 @@ type CmdWrapper struct {
 	Input    io.WriteCloser
 	BestMove chan string
 	Version  string
-	Ready	 bool
 }
 
 func (c *CmdWrapper) openInput() {
@@ -148,7 +147,6 @@ func (c *CmdWrapper) openInput() {
 
 func (c *CmdWrapper) launch(networkPath string, args []string, input bool) {
 	c.BestMove = make(chan string)
-	c.Ready = false
 	weights := fmt.Sprintf("--weights=%s", networkPath)
 	dir, _ := os.Getwd()
 	c.Cmd = exec.Command(path.Join(dir, "lczero"), weights, "-t1")
@@ -187,8 +185,6 @@ func (c *CmdWrapper) launch(networkPath string, args []string, input bool) {
 				c.BestMove <- strings.Split(line, " ")[1]
 			} else if strings.HasPrefix(line, "id name lczero ") {
 				c.Version = strings.Split(line, " ")[3]
-			} else if line == "readyok" {
-				c.Ready = true
 			}
 		}
 	}()
@@ -215,13 +211,9 @@ func playMatch(baselinePath string, candidatePath string, params []string, flip 
 	baseline.launch(baselinePath, params, true)
 	defer baseline.Input.Close()
 
-	io.WriteString(baseline.Input, "isready\n")
-
 	candidate := CmdWrapper{}
 	candidate.launch(candidatePath, params, true)
 	defer candidate.Input.Close()
-
-	io.WriteString(candidate.Input, "isready\n")
 
 	p1 := &candidate
 	p2 := &baseline
@@ -232,24 +224,6 @@ func playMatch(baselinePath string, candidatePath string, params []string, flip 
 
 	io.WriteString(baseline.Input, "uci\n")
 	io.WriteString(candidate.Input, "uci\n")
-
-	to_start := time.Now()
-
-	for {
-		if baseline.Ready && candidate.Ready {
-			break
-		}
-
-		to_now := time.Now()
-		to_diff := to_now.Sub(to_start)
-
-		if to_diff.Seconds() > 300 {
-			log.Println("readyok timeout")
-			return 0, "", "", errors.New("timeout")
-		}
-
-		time.Sleep(200 * time.Millisecond)
-	}
 
 	// Play a game using UCI
 	var result int

--- a/go/src/client/main.go
+++ b/go/src/client/main.go
@@ -247,6 +247,8 @@ func playMatch(baselinePath string, candidatePath string, params []string, flip 
 			log.Println("readyok timeout")
 			return 0, "", "", errors.New("timeout")
 		}
+
+		time.Sleep(200 * time.Millisecond)
 	}
 
 	// Play a game using UCI

--- a/src/Parameters.cpp
+++ b/src/Parameters.cpp
@@ -41,7 +41,6 @@ using namespace Utils;
 
 // Configuration flags
 bool cfg_allow_pondering;
-bool cfg_noinitialize;
 int cfg_max_threads;
 int cfg_num_threads;
 int cfg_max_playouts;
@@ -74,7 +73,6 @@ bool cfg_go_nodes_as_playouts;
 
 void Parameters::setup_default_parameters() {
     cfg_allow_pondering = false;
-    cfg_noinitialize = false;
     int num_cpus = std::thread::hardware_concurrency();
     cfg_max_threads = std::max(1, std::min(num_cpus, MAX_CPUS));
     cfg_num_threads = 2;

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -47,11 +47,9 @@ namespace {
 
   int net_init() {
 
-    if (!cfg_noinitialize)
-    {
+    if (!cfg_noinitialize) {
        Network::initialize();
     }
-
     return 0;
   }
 
@@ -398,15 +396,17 @@ void UCI::loop(const std::string& start) {
           Training::clear_training();
       }
       else if (token == "isready") {
-          if (wait_init)
-          {
-          wait_init = netinit.get(); // wait for network initialization
+          if (wait_init) {
+              wait_init = netinit.get(); // wait for network initialization
           }
           myprintf_so("readyok\n"); //"readyok" can be sent also when the engine is calculating
       }
       // Additional custom non-UCI commands, mainly for debugging
       else if (token == "train") {
           stop_and_wait_search();
+          if (wait_init) {
+              wait_init = netinit.get();
+          }
 
           generate_training_games(is);
       }

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -362,6 +362,9 @@ void UCI::loop(const std::string& start) {
           setoption(is);
       }
       else if (token == "go") {
+          if (wait_init) {
+              wait_init = netinit.get();
+          }
           wait_search();
 
           parse_limits(is, search);
@@ -408,6 +411,9 @@ void UCI::loop(const std::string& start) {
           generate_training_games(is);
       }
       else if (token == "bench") {
+          if (wait_init) {
+              wait_init = netinit.get();
+          }
           stop_and_wait_search();
 
           bench();

--- a/src/UCI.cpp
+++ b/src/UCI.cpp
@@ -46,10 +46,7 @@ namespace {
   // for async network initialization in UCI::loop()
 
   int net_init() {
-
-    if (!cfg_noinitialize) {
-       Network::initialize();
-    }
+    Network::initialize();
     return 0;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -384,11 +384,12 @@ int main(int argc, char* argv[]) {
 #endif
   thread_pool.initialize(cfg_num_threads);
   // Random::GetRng().seedrandom(cfg_rng_seed);
-  if (!cfg_noinitialize) {
-      Network::initialize();
-  }
 
   if (!cfg_supervise.empty()) {
+      if (!cfg_noinitialize)
+      {
+         Network::initialize();
+      }
       generate_supervised_data(cfg_supervise);
       return 0;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -386,8 +386,7 @@ int main(int argc, char* argv[]) {
   // Random::GetRng().seedrandom(cfg_rng_seed);
 
   if (!cfg_supervise.empty()) {
-      if (!cfg_noinitialize)
-      {
+      if (!cfg_noinitialize) {
          Network::initialize();
       }
       generate_supervised_data(cfg_supervise);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,8 +91,6 @@ static std::string parse_commandline(int argc, char *argv[]) {
         ("syzygypath,e", po::value<std::string>(), "Folder with syzygy endgame tablebases.")
         ("logfile,l", po::value<std::string>(), "File to log input/output to.")
         ("quiet,q", "Disable all diagnostic output.")
-        ("uci", "Don't initialize the engine until \"isready\" command is sent. Use this if your "
-                "GUI is freezing on startup.")
         ("start", po::value<std::string>(), "Start command {train, bench}.")
         ("supervise", po::value<std::string>(), "Dump supervised learning data from the pgn.")
 #ifdef USE_OPENCL
@@ -214,10 +212,6 @@ static std::string parse_commandline(int argc, char *argv[]) {
             myprintf("Using rng seed from cli, activating single thread mode!\n");
         }
         myprintf("RNG seed from cli: %llu\n", cfg_rng_seed);
-    }
-
-    if (vm.count("uci")) {
-        cfg_noinitialize = true;
     }
 
     if (vm.count("noise")) {
@@ -386,9 +380,7 @@ int main(int argc, char* argv[]) {
   // Random::GetRng().seedrandom(cfg_rng_seed);
 
   if (!cfg_supervise.empty()) {
-      if (!cfg_noinitialize) {
-         Network::initialize();
-      }
+      Network::initialize();
       generate_supervised_data(cfg_supervise);
       return 0;
   }


### PR DESCRIPTION
Start Network::initialize() as an async task after entering UCI::loop(). Wait for the task to complete after receiving "isready", do it only once. This should speed up the engine booting and increase the UCI protocol compatibility. Tested in Ubuntu for the intended functionality. 
