### PR TITLE
added a parameter "-r" - if present: rotate board, if omitted: old behaviour

### DIFF
--- a/training/tf/decode_training.py
+++ b/training/tf/decode_training.py
@@ -1999,8 +1999,13 @@ class TrainingStep:
         for r in range(8):
             for f in range(8):
                 # Note: Using 8-1-f because both the text and binary have the
-                # column bits reversed fhom what this code expects
-                if bit_board & (1<<(r*8+(8-1-f))):
+                # column bits reversed from what this code expects
+                
+                if self.us_black:
+                    correctedF = f
+                else:
+                    correctedF = 8-1-f
+                if bit_board & (1<<(r*8 + correctedF)):
                     assert(self.history[hist].board[r][f] == ".")
                     self.history[hist].board[r][f] = piece
 
@@ -2019,13 +2024,21 @@ class TrainingStep:
         else:
             raise Exception("Invalid winner: {}".format(self.winner))
         if self.us_black:
-            s += "(Note the black pieces are CAPS, black moves up, but A1 is in lower left)\n"
+            s += "(Note the black pieces are CAPS, black moves up)\n"
         s += "rule50_count {} b_ooo b_oo, w_ooo, w_oo {} {} {} {}\n".format(
             self.rule50_count, self.us_ooo, self.us_oo, self.them_ooo, self.them_oo)
-        s += "  abcdefgh\n"
+
         rank_strings = [[]]
-        for rank in reversed(range(8)):
-            rank_strings[0].append("{}".format(rank+1))
+
+        if self.us_black:
+            s += "  hgfedcba\n"
+            for rank in range(8):
+                rank_strings[0].append("{}".format(rank+1))
+        else:
+            s += "  abcdefgh\n"
+            for rank in reversed(range(8)):
+                rank_strings[0].append("{}".format(rank+1))
+            
         rank_strings[0].append("  ")
         for hist in range(self.NUM_HIST):
             rank_strings.append(self.history[hist].describe())
@@ -2040,8 +2053,13 @@ class TrainingStep:
             if prob > 0.01:
                 top_moves[idx] = prob
             sum += prob
+        if self.us_black:
+            lookupMap = self.new_rev_black_move_map
+        else:
+            lookupMap = self.new_rev_white_move_map
         for idx, prob in sorted(top_moves.items(), key=lambda x:-x[1]):
-            s += "{} {:4.1f}%\n".format(self.new_rev_white_move_map[idx], prob*100)
+            myuci = lookupMap[idx]
+            s += "{} {:4.1f}%\n".format(myuci, prob*100)
         #print("debug prob sum", sum, "cnt", len(self.probs))
         return s
 
@@ -2065,6 +2083,7 @@ class TrainingStep:
         assert self.version == int.from_bytes(ver, byteorder="little")
         # Enforce move_count to 0
         move_count = 0
+        self.us_black = us_black
         # Unpack planes.
         for hist in range(self.NUM_HIST):
             for idx, piece in enumerate(PIECES):
@@ -2078,7 +2097,6 @@ class TrainingStep:
         self.us_oo = us_oo
         self.them_ooo = them_ooo
         self.them_oo = them_oo
-        self.us_black = us_black
         self.rule50_count = rule50_count
         self.winner = winner
         for idx in range(0, len(probs), 4):


### PR DESCRIPTION
I made a regression test: game 11378912 - 226 moves: Output of the old version is exactly identical to the new version (when parameter "-r" is omitted)

If parameter "-r" is present then the board is rotated (for the black perspective)