### PR TITLE
Attempt to do better at estimating playouts remaining, while requiring less time to do so.

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -284,7 +284,7 @@ bool UCTSearch::is_running() const {
 }
 
 int UCTSearch::est_playouts_left() const {
-    auto elapsed_millis = now() - m_start_time;
+    auto elapsed_millis = now() - m_time_after_initial_playouts;
     auto playouts = m_playouts.load();
     if (!Limits.dynamic_controls_set() && !Limits.movetime) {
         // No time control, use playouts or visits.
@@ -292,9 +292,9 @@ int UCTSearch::est_playouts_left() const {
                 std::max(0, std::min(m_maxplayouts - playouts,
                                      m_maxnodes - m_root->get_visits()));
         return playouts_left;
-    } else if (elapsed_millis < 1000 || playouts < 100) {
-        // Until we reach 1 second or 100 playouts playout_rate
-        // is not reliable, so just return max.
+    } else if (elapsed_millis < 10 || playouts < 10) {
+        // Until we reach 10 millisecond and 10 playouts playout_rate
+        // is too risky to use, so just return max.
         return MAXINT_DIV2;
     } else {
         const auto playout_rate = 1.0f * playouts / elapsed_millis;
@@ -446,6 +446,7 @@ Move UCTSearch::think(BoardHistory&& new_bh) {
 
     bool keeprunning = true;
     int last_update = 0;
+    bool initial_playouts_done = false;
     do {
         auto currstate = bh_.shallow_clone();
         auto result = play_simulation(currstate, m_root.get(), 0);
@@ -458,7 +459,15 @@ Move UCTSearch::think(BoardHistory&& new_bh) {
             last_update = depth;
             dump_analysis(Time.elapsed(), false);
         }
-
+        if (!initial_playouts_done) {
+            // Always update this time stamp so the pruning check is against
+            // an initialized value.
+            m_time_after_initial_playouts = now();
+            // One playout per thread, before we consider things warmed up.
+            if (m_playouts >= cpus) {
+                initial_playouts_done = true;
+            }
+        }
         // check if we should still search
         keeprunning = is_running();
         keeprunning &= !should_halt_search();

--- a/src/UCTSearch.h
+++ b/src/UCTSearch.h
@@ -100,6 +100,7 @@ private:
     int64_t m_target_time{0};
     int64_t m_max_time{0};
     int64_t m_start_time{0};
+    int64_t m_time_after_initial_playouts{0};
     std::atomic<bool> m_run{false};
     int m_maxplayouts;
     int m_maxnodes;


### PR DESCRIPTION
Implementing the idea in #581. A key aspect here is that we shift the start time later, but we don't decrement the playouts by how many there are at that start time.  This means we generally shift from an underestimate that converges upwards, to an overestimate which mostly converges downwards and so inaccuracy due to early calculation is less likely to cause us to prune early.

I don't actually know if this provides an Elo win yet, but it does seem to provide an improvement in ability to estimate playouts at short time scales. I'm running a self-play tournament on 1+1 to start.

I think the logic may not currently be very sound with large thread count of slow evals though, if each of your threads can only do 50nps, but you have 40+ of them (aka TCEC), 10 playouts/10ms is basically not going to limit anything.  I need to think more about how to scale those constants with thread count.