### PR TITLE
Some build fixes for lc0 on Linux.

### DIFF
--- a/lc0/README.md
+++ b/lc0/README.md
@@ -6,7 +6,7 @@ Building is not very streightforward, but here's roughly the process:
 
 1. (if you want version with tensorflow) Install tensorflow_cc by following steps described [here](https://github.com/FloopCZ/tensorflow_cc).
 2. (if you want cuDNN version) Install CUDA and cuDNN.
-3. Install ninja and meson
+3. Install ninja, meson, and gtest (`libgtest-dev`).
 4. Go to lc0/
 5. If you decided not to install tensorflow or CUDA, comment out building network_tf.cc and/or network_cudnn.cu from meson.build.
 6. Run ./build.sh

--- a/lc0/README.md
+++ b/lc0/README.md
@@ -4,11 +4,11 @@ Building is not very streightforward, but here's roughly the process:
 
 ## Linux
 
-1. (if you want version with tensorflow) Install tensorflow_cc by following steps described [here](https://github.com/FloopCZ/tensorflow_cc).
+1. (if you want version with tensorflow) Install `tensorflow_cc` by following steps described [here](https://github.com/FloopCZ/tensorflow_cc).
 2. (if you want cuDNN version) Install CUDA and cuDNN.
 3. Install ninja, meson, and gtest (`libgtest-dev`).
 4. Go to lc0/
-5. If you decided not to install tensorflow or CUDA, comment out building network_tf.cc and/or network_cudnn.cu from meson.build.
+5. If you decided not to install tensorflow or CUDA, comment out building `network_tf.cc` and/or `network_cudnn.cu` from meson.build.
 6. Run ./build.sh
 
 If you want to build with a different compiler, pass the `CC` and `CXX` environment variables:

--- a/lc0/README.md
+++ b/lc0/README.md
@@ -11,6 +11,10 @@ Building is not very streightforward, but here's roughly the process:
 5. If you decided not to install tensorflow or CUDA, comment out building network_tf.cc and/or network_cudnn.cu from meson.build.
 6. Run ./build.sh
 
+If you want to build with a different compiler, pass the `CC` and `CXX` environment variables:
+
+    CC=clang-6.0 CXX=clang++-6.0 ./build.sh
+
 ## Windows
 
 Building for windows is currently complicated, you can try executeing steps listed [here](https://github.com/glinscott/leela-chess/issues/334#issuecomment-382848569).

--- a/lc0/README.md
+++ b/lc0/README.md
@@ -6,7 +6,7 @@ Building is not very streightforward, but here's roughly the process:
 
 1. (if you want version with tensorflow) Install `tensorflow_cc` by following steps described [here](https://github.com/FloopCZ/tensorflow_cc).
 2. (if you want cuDNN version) Install CUDA and cuDNN.
-3. Install ninja, meson, and gtest (`libgtest-dev`).
+3. Install ninja build (`ninja-build`), meson, and gtest (`libgtest-dev`).
 4. Go to lc0/
 5. If you decided not to install tensorflow or CUDA, comment out building `network_tf.cc` and/or `network_cudnn.cu` from meson.build.
 6. Run ./build.sh

--- a/lc0/build.sh
+++ b/lc0/build.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+CC=${CC:=clang}
+CXX=${CXX:=clang++}
+
 rm -fr build
-CC=clang CXX=clang++ meson build --buildtype release # -Db_ndebug=true
+CC=${CC} CXX=${CXX} meson build --buildtype release # -Db_ndebug=true
 # CC=clang CXX=clang++ meson build --buildtype debugoptimized -Db_asneeded=false
 # CC=clang CXX=clang++ meson build --buildtype debug
 cp testdata/* build


### PR DESCRIPTION
This is a partial fix for #532. It allows `CC` and `CXX` to be set outside `build.sh`, and documents the `gtest` build dependency.