### PR TITLE
 lc0: Create fake history when starting from a fen position with no history

### DIFF
--- a/lc0/src/chess/position.cc
+++ b/lc0/src/chess/position.cc
@@ -81,9 +81,19 @@ GameResult PositionHistory::ComputeGameResult() const {
 }
 
 void PositionHistory::Reset(const ChessBoard& board, int no_capture_ply,
-                            int game_ply) {
+                            int game_ply,bool clone_history) {
   positions_.clear();
-  positions_.emplace_back(board, no_capture_ply, game_ply);
+  if(clone_history){
+    ChessBoard mirrored = board;
+    mirrored.Mirror();
+    for(int i=0; i<4;i++)
+      positions_.emplace_back(board, no_capture_ply, game_ply);
+      positions_.push_back(positions_.back());
+      positions_.emplace_back(mirrored, no_capture_ply, game_ply);
+      positions_.push_back(positions_.back());
+   }
+   positions_.emplace_back(board, no_capture_ply, game_ply);
+
 }
 
 void PositionHistory::Append(Move m) {

--- a/lc0/src/chess/position.h
+++ b/lc0/src/chess/position.h
@@ -97,7 +97,7 @@ class PositionHistory {
   int GetLength() const { return positions_.size(); }
 
   // Resets the position to a given state.
-  void Reset(const ChessBoard& board, int no_capture_ply, int game_ply);
+  void Reset(const ChessBoard& board, int no_capture_ply, int game_ply, bool clone_history);
 
   // Appends a position to history.
   void Append(Move m);

--- a/lc0/src/mcts/node.cc
+++ b/lc0/src/mcts/node.cc
@@ -357,7 +357,8 @@ void NodeTree::ResetToPosition(const std::string& starting_fen,
   }
 
   history_.Reset(starting_board, no_capture_ply,
-                 full_moves * 2 - (starting_board.flipped() ? 1 : 2));
+                 full_moves * 2 - (starting_board.flipped() ? 1 : 2),
+                 ChessBoard::kStartingFen != starting_fen);
 
   Node* old_head = current_head_;
   current_head_ = gamebegin_node_;


### PR DESCRIPTION
Added copies of the current board position in history planes when a fen position with no history is specified (except the new board starting position)

This appears to greatly help evaluations compared to when history planes are empty.. eg with net315 it finds the Rxf3+ move with 1 node..

position fen 8/p7/3N2R1/P7/5K1k/1r3B2/1Pr4p/8 b - - 0 1
go nodes 1
Creating backend [cudnn]...
info string c2c3  (1445) N:       0 (+ 0) (V:   0.00%) (P:  0.06%) (Q:  0.14733) (U: 0.00070) (Q+U:  0.14803)
info string a7a6  (204 ) N:       0 (+ 0) (V:   0.00%) (P:  0.05%) (Q:  0.14733) (U: 0.00058) (Q+U:  0.14791)
info string h4h3  (1134) N:       0 (+ 0) (V:   0.00%) (P:  2.18%) (Q:  0.14733) (U: 0.02611) (Q+U:  0.17344)
info string b3b2  (1187) N:       0 (+ 0) (V:   0.00%) (P:  0.18%) (Q:  0.14733) (U: 0.00210) (Q+U:  0.14943)
info string b3b4  (1176) N:       0 (+ 0) (V:   0.00%) (P: 10.12%) (Q:  0.14733) (U: 0.12148) (Q+U:  0.26881)
info string b3b5  (1172) N:       0 (+ 0) (V:   0.00%) (P:  0.03%) (Q:  0.14733) (U: 0.00038) (Q+U:  0.14771)
info string b3b6  (1169) N:       0 (+ 0) (V:   0.00%) (P:  0.02%) (Q:  0.14733) (U: 0.00027) (Q+U:  0.14760)
info string b3b7  (1167) N:       0 (+ 0) (V:   0.00%) (P:  0.03%) (Q:  0.14733) (U: 0.00032) (Q+U:  0.14765)
info string b3b8  (1165) N:       0 (+ 0) (V:   0.00%) (P:  0.05%) (Q:  0.14733) (U: 0.00063) (Q+U:  0.14796)
info string b3c3  (1180) N:       0 (+ 0) (V:   0.00%) (P:  0.02%) (Q:  0.14733) (U: 0.00026) (Q+U:  0.14759)
info string b3d3  (1181) N:       0 (+ 0) (V:   0.00%) (P:  0.06%) (Q:  0.14733) (U: 0.00070) (Q+U:  0.14803)
info string b3e3  (1182) N:       0 (+ 0) (V:   0.00%) (P:  0.04%) (Q:  0.14733) (U: 0.00048) (Q+U:  0.14781)
info string b3f3  (1183) N:       0 (+ 0) (V:   0.00%) (P: 58.03%) (Q:  0.14733) (U: 0.69633) (Q+U:  0.84366)
info string b3a3  (1179) N:       0 (+ 0) (V:   0.00%) (P:  0.04%) (Q:  0.14733) (U: 0.00046) (Q+U:  0.14779)
info string c2c1  (1457) N:       0 (+ 0) (V:   0.00%) (P:  0.71%) (Q:  0.14733) (U: 0.00854) (Q+U:  0.15587)
info string h2h1n (1597) N:       0 (+ 0) (V:   0.00%) (P:  0.16%) (Q:  0.14733) (U: 0.00197) (Q+U:  0.14930)
info string c2c4  (1440) N:       0 (+ 0) (V:   0.00%) (P:  0.19%) (Q:  0.14733) (U: 0.00233) (Q+U:  0.14967)
info string c2c5  (1436) N:       0 (+ 0) (V:   0.00%) (P:  0.19%) (Q:  0.14733) (U: 0.00222) (Q+U:  0.14955)
info string c2c6  (1434) N:       0 (+ 0) (V:   0.00%) (P:  0.05%) (Q:  0.14733) (U: 0.00059) (Q+U:  0.14792)
info string c2c7  (1432) N:       0 (+ 0) (V:   0.00%) (P:  0.07%) (Q:  0.14733) (U: 0.00084) (Q+U:  0.14817)
info string c2c8  (1431) N:       0 (+ 0) (V:   0.00%) (P:  0.04%) (Q:  0.14733) (U: 0.00046) (Q+U:  0.14779)
info string c2d2  (1450) N:       0 (+ 0) (V:   0.00%) (P:  0.23%) (Q:  0.14733) (U: 0.00277) (Q+U:  0.15010)
info string c2e2  (1451) N:       0 (+ 0) (V:   0.00%) (P:  0.11%) (Q:  0.14733) (U: 0.00135) (Q+U:  0.14868)
info string c2f2  (1452) N:       0 (+ 0) (V:   0.00%) (P: 26.52%) (Q:  0.14733) (U: 0.31829) (Q+U:  0.46562)
info string c2g2  (1453) N:       0 (+ 0) (V:   0.00%) (P:  0.07%) (Q:  0.14733) (U: 0.00081) (Q+U:  0.14814)
info string c2b2  (1449) N:       0 (+ 0) (V:   0.00%) (P:  0.22%) (Q:  0.14733) (U: 0.00259) (Q+U:  0.14992)
info string h2h1q (1855) N:       0 (+ 0) (V:   0.00%) (P:  0.27%) (Q:  0.14733) (U: 0.00324) (Q+U:  0.15057)
info string h2h1r (1856) N:       0 (+ 0) (V:   0.00%) (P:  0.16%) (Q:  0.14733) (U: 0.00192) (Q+U:  0.14926)
info string h2h1b (1857) N:       0 (+ 0) (V:   0.00%) (P:  0.11%) (Q:  0.14733) (U: 0.00129) (Q+U:  0.14863)
bestmove b3f3