### PR TITLE
Use system zlib when available, tested on archlinux

### DIFF
--- a/lc0/meson.build
+++ b/lc0/meson.build
@@ -180,9 +180,16 @@ endif
   ## ~~~~
   ## zlib
   ## ~~~~
-  # Pick latest from https://wrapdb.mesonbuild.com/zlib and put into
-  # subprojects/zlib.wrap
-  deps += subproject('zlib').get_variable('zlib_dep')
+  # Use either native zlib or pick latest from
+  # https://wrapdb.mesonbuild.com/zlib and put into subprojects/zlib.wrap
+
+  zlib_dep = dependency('zlib', required : false)
+  if zlib_dep.found()
+    deps += zlib_dep
+  else
+    deps += subproject('zlib').get_variable('zlib_dep')
+  endif
+ 
 
   ## ~~~~~~~~
   ## Profiler


### PR DESCRIPTION
Haven't worked with meson before, so I hope it does not break things on other platforms. See here: http://mesonbuild.com/Dependencies.html