### PR TITLE
Added Policy Softmax Temperature option

### DIFF
--- a/lc0/src/mcts/search.cc
+++ b/lc0/src/mcts/search.cc
@@ -219,7 +219,7 @@ void Search::Worker() {
         for (Node* n : node->Children()) {
           float p = computation.GetPVal(idx_in_computation,
                                         n->GetMove().as_nn_index());
-          if(p > 0.0f){
+          if(KPolicySoftmaxTemp != 1.0f && p != 1.0f && p > 0.0f){
               p = pow(p, 1/KPolicySoftmaxTemp);
           }
           total += p;

--- a/lc0/src/mcts/search.cc
+++ b/lc0/src/mcts/search.cc
@@ -46,6 +46,7 @@ const char* Search::kFpuReductionStr = "First Play Urgency Reduction";
 const char* Search::kCacheHistoryLengthStr =
     "Length of history to include in cache";
 const char* Search::kExtraVirtualLossStr = "Extra virtual loss";
+const char* Search::KPolicySoftmaxTempStr = "Policy softmax temperature";
 
 namespace {
 const int kSmartPruningToleranceNodes = 100;
@@ -69,6 +70,7 @@ void Search::PopulateUciParams(OptionsParser* options) {
                           "cache-history-length") = 7;
   options->Add<FloatOption>(kExtraVirtualLossStr, 0.0, 100.0,
                             "extra-virtual-loss") = 0.0f;
+  options->Add<FloatOption>(KPolicySoftmaxTempStr, 0.1, 10.0, "policy-softmax-temp") = 1.0f;
 }
 
 Search::Search(const NodeTree& tree, Network* network,
@@ -95,7 +97,8 @@ Search::Search(const NodeTree& tree, Network* network,
       kVirtualLossBug(options.Get<float>(kVirtualLossBugStr)),
       kFpuReduction(options.Get<float>(kFpuReductionStr)),
       kCacheHistoryLength(options.Get<int>(kCacheHistoryLengthStr)),
-      kExtraVirtualLoss(options.Get<float>(kExtraVirtualLossStr)) {}
+      kExtraVirtualLoss(options.Get<float>(kExtraVirtualLossStr)),
+      KPolicySoftmaxTemp(options.Get<float>(KPolicySoftmaxTempStr)) {}
 
 // Returns whether node was already in cache.
 bool Search::AddNodeToCompute(Node* node, CachingComputation* computation,
@@ -216,6 +219,9 @@ void Search::Worker() {
         for (Node* n : node->Children()) {
           float p = computation.GetPVal(idx_in_computation,
                                         n->GetMove().as_nn_index());
+          if(p > 0.0f){
+              p = pow(p, 1/KPolicySoftmaxTemp);
+          }
           total += p;
           n->SetP(p);
         }

--- a/lc0/src/mcts/search.cc
+++ b/lc0/src/mcts/search.cc
@@ -219,7 +219,7 @@ void Search::Worker() {
         for (Node* n : node->Children()) {
           float p = computation.GetPVal(idx_in_computation,
                                         n->GetMove().as_nn_index());
-          if(KPolicySoftmaxTemp != 1.0f && p != 1.0f && p > 0.0f){
+          if(KPolicySoftmaxTemp != 1.0f){
               p = pow(p, 1/KPolicySoftmaxTemp);
           }
           total += p;

--- a/lc0/src/mcts/search.h
+++ b/lc0/src/mcts/search.h
@@ -84,6 +84,7 @@ class Search {
   static const char* kFpuReductionStr;
   static const char* kCacheHistoryLengthStr;
   static const char* kExtraVirtualLossStr;
+  static const char* KPolicySoftmaxTempStr;
 
  private:
   // Can run several copies of it in separate threads.
@@ -155,6 +156,7 @@ class Search {
   const float kFpuReduction;
   const bool kCacheHistoryLength;
   const float kExtraVirtualLoss;
+  const float KPolicySoftmaxTemp;
 };
 
 }  // namespace lczero


### PR DESCRIPTION
This enables setting the temperature of the policy softmax. I'm trying this because of the tactical problem cases that have been shown to arise from the policy head assigning unreasonably low (a few hundredths of a percent) to the relevant moves. Increasing highly-disfavored moves from a few hundredths of a percent to a few tenths of a percent (as would be accomplished by a small temperature, perhaps 1.5-2) does reduce search depth (go movetime 60000 from startpos produces, with temp=1, the normal behavior, seldepth 38 and 247k nodes. With temp=1.5 this results in seldepth 30 and 240k nodes) but it also significantly improves cases such as the following case brought up by Faroe22 in the discord.

1. d4 Nf6 2. c4 e6 3. Nf3 d5 4. cxd5 exd5 5. Nc3 Bd6 6. Bg5 c6 7. Qc2 O-O 8. e3 Re8 9. Bd3 h6 10. Bh4 Be6 11. O-O Nbd7 12. Bg3 Bxg3 13. hxg3 Ng4 14. b4 Rc8 15. a4 Ndf6 16. a5 Bd7 17. Na4 b6 18. axb6 axb6 19. Nd2 Ra8 20. Rfe1 g6 21. Nf1 Kg7 22. Rec1 h5 23. Qb2 c5 24. b5 c4 25. Be2 Rh8 26. Nc3 Rxa1 27. Rxa1 h4 28. gxh4 Rxh4 29. Qa3 Qh8 30. Ng3 Rh1+ 31. Nxh1 Qh2+ 32. Kf1 0-1

move 30. Ng3 is a massive blunder, resulting in a mate in 3. at temp=1, it takes 90k nodes for leela to switch away from Ng3, whereas with temp=1.5 it takes only 37k, a more than twofold improvement.

I have not been able to thoroughly test the effects of non-one temperatures, I'm currently running a CLOP test at ultra-short time controls vs stockfish and that seems to be vaguely gesturing towards a value of two being better than one, but it hasn't been running long enough to be sure. 

The main purpose of this PR is to encourage further testing of this parameter to see if non-one values are at all advantageous, and if so what the optimal values and tradeoffs are.