### PR TITLE
decode_training: Include all moves with at least 1 visit.

### DIFF
--- a/training/tf/decode_training.py
+++ b/training/tf/decode_training.py
@@ -2037,7 +2037,8 @@ class TrainingStep:
         sum = 0.0
         top_moves = {}
         for idx, prob in enumerate(self.probs):
-            if prob > 0.01:
+            # Include all moves with at least 1 visit.
+            if prob > 0.0:
                 top_moves[idx] = prob
             sum += prob
         for idx, prob in sorted(top_moves.items(), key=lambda x:-x[1]):


### PR DESCRIPTION
Fix this issue that caused some confusion awhile back when analyzing training games.
