### PR TITLE
Change isready to call UpdateNetwork so backends initialize

### DIFF
--- a/lc0/src/engine.cc
+++ b/lc0/src/engine.cc
@@ -202,6 +202,8 @@ void EngineLoop::CmdUci() {
 }
 
 void EngineLoop::CmdIsReady() {
+  EnsureOptionsSent();
+  engine_.UpdateNetwork();
   engine_.EnsureReady();
   SendResponse("readyok");
 }

--- a/lc0/src/engine.h
+++ b/lc0/src/engine.h
@@ -43,6 +43,8 @@ class EngineController {
     search_.reset();
   }
 
+  void UpdateNetwork();
+
   void PopulateOptions(OptionsParser* options);
 
   // Blocks.
@@ -65,8 +67,6 @@ class EngineController {
                                     const GoParams& params);
 
  private:
-  void UpdateNetwork();
-
   const OptionsDict& options_;
 
   BestMoveInfo::Callback best_move_callback_;


### PR DESCRIPTION
I think UCI expects isready to block and do all long operations, so for us that should include backend initialization. From the examples I think all setoptions should be done before this so we will know the network the user wants by now.

I made engine::UpdateNetwork public instead of private to do this, let me know if you want to do it differently. I also called EnsureOptionsSent, not sure if we need that or other things.
